### PR TITLE
refactor : 만료 AccessToken 오류 해결

### DIFF
--- a/src/main/java/org/project/sohwagi/schedule/adapter/in/web/ScheduleController.java
+++ b/src/main/java/org/project/sohwagi/schedule/adapter/in/web/ScheduleController.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import java.net.URI;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.project.sohwagi.common.UserInfo;
 import org.project.sohwagi.schedule.adapter.in.web.response.ScheduleResponse;
 import org.project.sohwagi.schedule.adapter.in.web.request.ScheduleTextRequest;
 import org.project.sohwagi.schedule.application.domain.service.ScheduleService;
@@ -13,6 +14,7 @@ import org.project.sohwagi.schedule.application.port.in.query.GetScheduleListQue
 import org.project.sohwagi.schedule.application.port.in.usecase.CreateScheduleUseCase;
 import org.project.sohwagi.schedule.application.port.in.usecase.DeleteScheduleUseCase;
 import org.project.sohwagi.schedule.application.port.in.usecase.GetScheduleUseCase;
+import org.project.sohwagi.user.UserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -27,13 +29,13 @@ public class ScheduleController {
 
 	@PostMapping
 	public ResponseEntity<String> createSchedule(@RequestBody ScheduleTextRequest request,
-		@RequestAttribute("userId") Long userId)
+		@UserInfo UserDetails userDetails)
 		throws JsonProcessingException {
 
 		CreateScheduleByTextCommand command = CreateScheduleByTextCommand
 			.builder()
 			.text(request.getText())
-			.userId(userId)
+			.userId(userDetails.id())
 			.build();
 
 		Long scheduleId = createScheduleUseCase.createScheduleByText(command);
@@ -43,11 +45,11 @@ public class ScheduleController {
 
 	@GetMapping
 	public ResponseEntity<List<ScheduleResponse>> getSchedules(
-		@RequestAttribute("userId") Long userId) {
+			@UserInfo UserDetails userDetails) {
 
 		GetScheduleListQuery query = GetScheduleListQuery
 			.builder()
-			.userId(userId)
+			.userId(userDetails.id())
 			.build();
 
 		List<ScheduleResponse> scheduleResponses = getScheduleUseCase.getScheduleList(query);
@@ -57,11 +59,11 @@ public class ScheduleController {
 
 	@DeleteMapping("/{scheduleId}")
 	public ResponseEntity<String> deleteSchedule(@PathVariable Long scheduleId,
-		@RequestAttribute("userId") Long userId) {
+			@UserInfo UserDetails userDetails) {
 		DeleteScheduleCommand command = DeleteScheduleCommand
 			.builder()
 			.scheduleId(scheduleId)
-			.userId(userId)
+			.userId(userDetails.id())
 			.build();
 
 		deleteScheduleUseCase.deleteSchedule(command);

--- a/src/main/java/org/project/sohwagi/token/TokenService.java
+++ b/src/main/java/org/project/sohwagi/token/TokenService.java
@@ -1,18 +1,22 @@
 package org.project.sohwagi.token;
 
 import org.project.sohwagi.token.dto.service.RefreshTokenCommand;
+import org.project.sohwagi.util.JwtUtil;
 import org.springframework.stereotype.Service;
 
 @Service
 public class TokenService {
 
-  private TokenRepository tokenRepository;
+  private final JwtUtil jwtUtil;
+  private final TokenRepository tokenRepository;
 
-  public TokenService(TokenRepository tokenRepository){
+  public TokenService(TokenRepository tokenRepository, JwtUtil jwtUtil){
     this.tokenRepository = tokenRepository;
+    this.jwtUtil = jwtUtil;
   }
 
   public String saveToken(RefreshTokenCommand command){
+
     Token token = Token.builder()
         .refreshToken(command.refreshToken())
         .isExpired(false)

--- a/src/main/java/org/project/sohwagi/util/JwtUtil.java
+++ b/src/main/java/org/project/sohwagi/util/JwtUtil.java
@@ -15,11 +15,13 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Date;
+import lombok.extern.slf4j.Slf4j;
 import org.project.sohwagi.common.TokenValidationResult;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
+@Slf4j
 @Component
 public class JwtUtil {
 
@@ -80,13 +82,17 @@ public class JwtUtil {
   public Long getUserInfoFromToken(String token, boolean isAccessToken) {
     Key key = isAccessToken ? accessKey : refreshKey;
 
+    log.info("getUserInfo");
+
     String userId = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody()
         .getSubject();
 
+    log.info(userId);
     return Long.valueOf(userId);
   }
 
   public String substringToken(String tokenValue) {
+    log.info("tokenvalue : " + tokenValue);
     if (!StringUtils.hasText(tokenValue) || !tokenValue.startsWith(BEARER_PREFIX)) {
       throw new JwtException(INVALID_JWT_SIGNATURE);
     }
@@ -94,14 +100,16 @@ public class JwtUtil {
     return tokenValue.substring(7);
   }
 
-  public String getJwtFromRequest(HttpServletRequest request) {
-    return request.getHeader(AUTHORIZATION_HEADER);
+  public String getJwtFromRequest(HttpServletRequest request, boolean isAccessToken) {
+    String headerName = isAccessToken ? "X-ACCESS-TOKEN" : "X-REFRESH-TOKEN";
+    return request.getHeader(headerName);
   }
 
   public TokenValidationResult validateToken(String token, boolean isAccessToken) {
     try {
       Key key = isAccessToken ? accessKey : refreshKey;
 
+      log.info("validate 토큰");
       token = substringToken(token);
 
       Jwts.parserBuilder()

--- a/src/main/java/org/project/sohwagi/util/LoginInterceptor.java
+++ b/src/main/java/org/project/sohwagi/util/LoginInterceptor.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.tomcat.util.http.parser.Authorization;
 import org.project.sohwagi.common.TokenValidationResult;
 import org.project.sohwagi.token.TokenService;
 import org.project.sohwagi.user.UserService;
@@ -25,7 +26,7 @@ public class LoginInterceptor implements HandlerInterceptor {
     log.info(request.getRequestURI());
     String accessToken = request.getHeader("X-ACCESS-TOKEN");
     String refreshToken = request.getHeader("X-REFRESH-TOKEN");
-    log.info(refreshToken);
+    log.info("Prehandle 시작 : "+refreshToken);
 
     if (accessToken == null || refreshToken == null) {
       throw new JwtException("Missing access or refresh token");
@@ -42,13 +43,20 @@ public class LoginInterceptor implements HandlerInterceptor {
     if (accessTokenResult == TokenValidationResult.EXPIRED) {
       TokenValidationResult refreshTokenResult = jwtUtil.validateToken(refreshToken, false);
       log.info(refreshTokenResult.toString());
+
       if (refreshTokenResult == TokenValidationResult.VALID) {
-        Long userId = jwtUtil.getUserInfoFromToken(refreshToken, false);
+        log.info("getUserInfo 전");
+        String substringToken = jwtUtil.substringToken(refreshToken);
+        Long userId = jwtUtil.getUserInfoFromToken(substringToken, false);
+        log.info("getUserInfo 후");
+
 
         if (tokenService.checkToken(refreshToken)) { // Port로 DB 검증
+          log.info("토큰 검증완료");
           String newAccessToken = jwtUtil.createAccessToken(userId);
-          response.setHeader("New-Access-Token", newAccessToken); // api 요청 결과와 함께 응답 헤더에 담김
+          response.setHeader("NEW-ACCESS-TOKEN", newAccessToken); // api 요청 결과와 함께 응답 헤더에 담김
           request.setAttribute("isAccessToken", false);
+
           return true;
         } else {
           throw new JwtException("Invalid refresh token in database");

--- a/src/main/java/org/project/sohwagi/util/UserInfoArgumentResolver.java
+++ b/src/main/java/org/project/sohwagi/util/UserInfoArgumentResolver.java
@@ -32,14 +32,17 @@ public class UserInfoArgumentResolver implements HandlerMethodArgumentResolver {
       NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
     HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
 
-    String tokenValue = jwtUtil.getJwtFromRequest(request);
+    Boolean isAccessToken = (Boolean) request.getAttribute("isAccessToken");
+
+    String tokenValue = jwtUtil.getJwtFromRequest(request, isAccessToken);
     String token = jwtUtil.substringToken(tokenValue);
 
-    Boolean isAccessToken = (Boolean) request.getAttribute("isAccessToken");
+    log.info(isAccessToken.toString());
     if (isAccessToken == null) {
       throw new IllegalArgumentException("Token type not found");
     }
 
+    log.info(token);
     // JWT 파싱을 통해 사용자 정보 추출
     Long userId = jwtUtil.getUserInfoFromToken(token, isAccessToken);
     log.info(userId.toString());


### PR DESCRIPTION
## 개요
```java
public String getJwtFromRequest(HttpServletRequest request) {
    return request.getHeader(AUTHORIZATION_HEADER);
  }
``` 
- 해당 로직에서 만료된 accessToken 인 경우에는 refreshToken을 가져와야 하는데 동일하게 accessToken을 가져와서 오류가 발생함
- 아래처럼 수정
- accessToken이 만료되었지만 refreshToken이 만료되지 않은 경우, 200은 주는데 새로운 accessToken을 response header에 넘겨줌
```java
  public String getJwtFromRequest(HttpServletRequest request, boolean isAccessToken) {
    String headerName = isAccessToken ? "X-ACCESS-TOKEN" : "X-REFRESH-TOKEN";
    return request.getHeader(headerName);
  }
``` 

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
