### PR TITLE
refactor : 엑세스 토큰 만료 에러 수정 - response header가 아니라 response body로

### DIFF
--- a/src/main/java/org/project/sohwagi/common/exception/AccessTokenException.java
+++ b/src/main/java/org/project/sohwagi/common/exception/AccessTokenException.java
@@ -1,0 +1,17 @@
+package org.project.sohwagi.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AccessTokenException extends RuntimeException{
+
+  private final String newAccessToken;
+
+  public AccessTokenException(String message, String newAccessToken){
+    super(message);
+    this.newAccessToken = newAccessToken;
+  }
+
+
+
+}

--- a/src/main/java/org/project/sohwagi/common/exception/ExceptionController.java
+++ b/src/main/java/org/project/sohwagi/common/exception/ExceptionController.java
@@ -2,6 +2,7 @@ package org.project.sohwagi.common.exception;
 
 import io.jsonwebtoken.JwtException;
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.http.HttpServletResponse;
 import java.nio.file.AccessDeniedException;
 import java.util.NoSuchElementException;
 import org.springframework.dao.DuplicateKeyException;
@@ -52,12 +53,29 @@ public class ExceptionController {
     return createResponse(HttpStatus.UNAUTHORIZED, e.getMessage());
   }
 
+  @ExceptionHandler(
+      AccessTokenException.class
+  )
+  public ResponseEntity<ExceptionDto> handleAccessTokenException(AccessTokenException e) {
+    return createAccessTokenResponse(HttpStatus.FORBIDDEN, e.getMessage(), e.getNewAccessToken());
+  }
+
   private ResponseEntity<ExceptionDto> createResponse(HttpStatus status, String message) {
     return ResponseEntity.status(status.value())
         .body(ExceptionDto.builder()
             .statusCode(status.value())
             .state(status)
             .message(message)
+            .build());
+  }
+
+  private ResponseEntity<ExceptionDto> createAccessTokenResponse(HttpStatus status, String message, String newAccessToken){
+    return ResponseEntity.status(status.value())
+        .body(ExceptionDto.builder()
+            .statusCode(status.value())
+            .state(status)
+            .message(message)
+            .newAccessToken(newAccessToken)
             .build());
   }
 }

--- a/src/main/java/org/project/sohwagi/common/exception/ExceptionDto.java
+++ b/src/main/java/org/project/sohwagi/common/exception/ExceptionDto.java
@@ -11,6 +11,6 @@ public class ExceptionDto {
   private int statusCode;
   private HttpStatus state;
   private String message;
-
+  private String newAccessToken;
 }
 

--- a/src/main/java/org/project/sohwagi/util/LoginInterceptor.java
+++ b/src/main/java/org/project/sohwagi/util/LoginInterceptor.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.tomcat.util.http.parser.Authorization;
 import org.project.sohwagi.common.TokenValidationResult;
+import org.project.sohwagi.common.exception.AccessTokenException;
 import org.project.sohwagi.common.exception.RefreshTokenException;
 import org.project.sohwagi.token.TokenService;
 import org.project.sohwagi.user.UserService;
@@ -40,38 +41,29 @@ public class LoginInterceptor implements HandlerInterceptor {
       return true;
     }
 
-    try {
-      if (accessTokenResult == TokenValidationResult.EXPIRED){
-        log.info("access-token-state : "+accessTokenResult.toString());
-        log.error("엑세스 토큰 만료. 에러 던집니다.");
+    if (accessTokenResult == TokenValidationResult.EXPIRED){
+      log.info("access-token-state : "+accessTokenResult.toString());
 
-        throw new JwtException("엑세스 토큰 만료");
+    }
+
+    TokenValidationResult refreshTokenResult = jwtUtil.validateToken(refreshToken, false);
+    log.info(refreshTokenResult.toString());
+
+    if (refreshTokenResult == TokenValidationResult.VALID) {
+      log.info("getUserInfo 전");
+      String substringToken = jwtUtil.substringToken(refreshToken);
+      Long userId = jwtUtil.getUserInfoFromToken(substringToken, false);
+      log.info("getUserInfo 후");
+
+
+      if (!tokenService.checkToken(refreshToken)) { // Port로 DB 검증
+        log.info("토큰 검증완료");
+        String newAccessToken = jwtUtil.createAccessToken(userId);
+        throw new AccessTokenException("엑세스 토큰 만료", newAccessToken);
+
+      } else {
+        throw new RefreshTokenException("RefreshToken 만료되었습니다. 로그인 필요합니다.");
       }
-    } catch (JwtException e){
-      log.error("JwtException 감지");
-
-      TokenValidationResult refreshTokenResult = jwtUtil.validateToken(refreshToken, false);
-      log.info(refreshTokenResult.toString());
-
-      if (refreshTokenResult == TokenValidationResult.VALID) {
-        log.info("getUserInfo 전");
-        String substringToken = jwtUtil.substringToken(refreshToken);
-        Long userId = jwtUtil.getUserInfoFromToken(substringToken, false);
-        log.info("getUserInfo 후");
-
-
-        if (!tokenService.checkToken(refreshToken)) { // Port로 DB 검증
-          log.info("토큰 검증완료");
-          String newAccessToken = jwtUtil.createAccessToken(userId);
-          response.setHeader("NEW-ACCESS-TOKEN", newAccessToken); // api 요청 결과와 함께 응답 헤더에 담김
-          request.setAttribute("isAccessToken", false);
-
-        } else {
-          throw new RefreshTokenException("RefreshToken 만료되었습니다. 로그인 필요합니다.");
-        }
-      }
-
-      throw e;
     }
 
     throw new JwtException("Invalid tokens");


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 클라이언트에서 NewAccessToken 헤더를 감지 하지 못하는 이슈에 따라서 새로운 엑세스 토큰을 response 헤더가 아니라 바디에 담아주도록 변경
<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
