### PR TITLE
#28 빌드 실패 오류 해결 -  bcprov-jdk15on 존재하는 최신 버전으로 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,8 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     implementation 'com.auth0:java-jwt:4.4.0'
-    implementation 'org.bouncycastle:bcprov-jdk15on:1.77'
-    implementation 'org.bouncycastle:bcpkix-jdk15on:1.70'
+    implementation 'org.bouncycastle:bcprov-jdk15on:1.76'
+    implementation 'org.bouncycastle:bcpkix-jdk15on:1.76'
 
 }
 


### PR DESCRIPTION
## 📄 작업 내역
- bcprov-jdk15on 존재하는 최신 버전으로 설정

## 🗣️ 의사결정 흐름

## 🔗 관련 이슈
