### PR TITLE
일정 리스트 조회 응답 구조 변경 - 주차 기준 그룹화된 구조로 변경

### DIFF
--- a/src/main/java/org/project/sohwagi/schedule/adapter/in/web/ScheduleController.java
+++ b/src/main/java/org/project/sohwagi/schedule/adapter/in/web/ScheduleController.java
@@ -44,7 +44,7 @@ public class ScheduleController {
 	}
 
 	@GetMapping
-	public ResponseEntity<List<ScheduleResponse.ScheduleDetailResponse>> getSchedules(
+	public ResponseEntity<List<ScheduleResponse.WeekGroupedScheduleResponse>> getSchedules(
 			@UserInfo UserDetails userDetails) {
 
 		GetScheduleListQuery query = GetScheduleListQuery
@@ -52,7 +52,7 @@ public class ScheduleController {
 			.userId(userDetails.id())
 			.build();
 
-		List<ScheduleResponse.ScheduleDetailResponse> scheduleResponses = getScheduleUseCase.getScheduleList(query);
+		List<ScheduleResponse.WeekGroupedScheduleResponse> scheduleResponses = getScheduleUseCase.getScheduleList(query);
 
 		return ResponseEntity.ok().body(scheduleResponses);
 	}

--- a/src/main/java/org/project/sohwagi/schedule/adapter/in/web/ScheduleController.java
+++ b/src/main/java/org/project/sohwagi/schedule/adapter/in/web/ScheduleController.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import java.net.URI;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.annotations.Parameter;
 import org.project.sohwagi.common.UserInfo;
 import org.project.sohwagi.schedule.adapter.in.web.response.ScheduleResponse;
 import org.project.sohwagi.schedule.adapter.in.web.request.ScheduleTextRequest;
@@ -45,12 +46,10 @@ public class ScheduleController {
 
 	@GetMapping
 	public ResponseEntity<List<ScheduleResponse.WeekGroupedScheduleResponse>> getSchedules(
+			@RequestParam int year, @RequestParam int month,
 			@UserInfo UserDetails userDetails) {
 
-		GetScheduleListQuery query = GetScheduleListQuery
-			.builder()
-			.userId(userDetails.id())
-			.build();
+		GetScheduleListQuery query = new GetScheduleListQuery(userDetails.id(), year, month);
 
 		List<ScheduleResponse.WeekGroupedScheduleResponse> scheduleResponses = getScheduleUseCase.getScheduleList(query);
 

--- a/src/main/java/org/project/sohwagi/schedule/adapter/in/web/ScheduleController.java
+++ b/src/main/java/org/project/sohwagi/schedule/adapter/in/web/ScheduleController.java
@@ -44,7 +44,7 @@ public class ScheduleController {
 	}
 
 	@GetMapping
-	public ResponseEntity<List<ScheduleResponse>> getSchedules(
+	public ResponseEntity<List<ScheduleResponse.ScheduleDetailResponse>> getSchedules(
 			@UserInfo UserDetails userDetails) {
 
 		GetScheduleListQuery query = GetScheduleListQuery
@@ -52,7 +52,7 @@ public class ScheduleController {
 			.userId(userDetails.id())
 			.build();
 
-		List<ScheduleResponse> scheduleResponses = getScheduleUseCase.getScheduleList(query);
+		List<ScheduleResponse.ScheduleDetailResponse> scheduleResponses = getScheduleUseCase.getScheduleList(query);
 
 		return ResponseEntity.ok().body(scheduleResponses);
 	}

--- a/src/main/java/org/project/sohwagi/schedule/adapter/in/web/response/ScheduleResponse.java
+++ b/src/main/java/org/project/sohwagi/schedule/adapter/in/web/response/ScheduleResponse.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.project.sohwagi.schedule.application.domain.model.Schedule;
 
+import java.util.List;
+
 public class ScheduleResponse {
 
 	@AllArgsConstructor
@@ -36,4 +38,14 @@ public class ScheduleResponse {
 					+ String.format("%02d", schedule.getMinute()) + "분";
 		}
 	}
+
+	@Getter
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class WeekGroupedScheduleResponse {
+		private String week;
+		private String periodOfWeek;
+		private List<ScheduleDetailResponse> schedules;
+	}
+
 }

--- a/src/main/java/org/project/sohwagi/schedule/adapter/in/web/response/ScheduleResponse.java
+++ b/src/main/java/org/project/sohwagi/schedule/adapter/in/web/response/ScheduleResponse.java
@@ -6,27 +6,29 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.project.sohwagi.schedule.application.domain.model.Schedule;
 
-@AllArgsConstructor
-@NoArgsConstructor
-@Getter
 public class ScheduleResponse {
 
-	private Long scheduleId;
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Getter
+	public static class ScheduleDetailResponse {
 
-	private String title;
+		private Long scheduleId;
 
-	private int month;
+		private String title;
 
-	private int day;
+		private int month;
 
-	private String dayOfWeek;
+		private int day;
 
-	public ScheduleResponse(Schedule schedule) {
-		this.scheduleId = schedule.getId();
-		this.title = schedule.getTitle();
-		this.month = schedule.getMonth();
-		this.day = schedule.getDay();
-		this.dayOfWeek = schedule.getDayOfWeek();
+		private String dayOfWeek;
+
+		public ScheduleDetailResponse(Schedule schedule) {
+			this.scheduleId = schedule.getId();
+			this.title = schedule.getTitle();
+			this.month = schedule.getMonth();
+			this.day = schedule.getDay();
+			this.dayOfWeek = schedule.getDayOfWeek();
+		}
 	}
-
 }

--- a/src/main/java/org/project/sohwagi/schedule/adapter/in/web/response/ScheduleResponse.java
+++ b/src/main/java/org/project/sohwagi/schedule/adapter/in/web/response/ScheduleResponse.java
@@ -23,12 +23,17 @@ public class ScheduleResponse {
 
 		private String dayOfWeek;
 
+		private String time;
+
 		public ScheduleDetailResponse(Schedule schedule) {
 			this.scheduleId = schedule.getId();
 			this.title = schedule.getTitle();
 			this.month = schedule.getMonth();
 			this.day = schedule.getDay();
 			this.dayOfWeek = schedule.getDayOfWeek();
+			this.time = schedule.getAmPm() + " "
+					+ schedule.getHour() + "시 "
+					+ String.format("%02d", schedule.getMinute()) + "분";
 		}
 	}
 }

--- a/src/main/java/org/project/sohwagi/schedule/adapter/out/gpt/GptAdapter.java
+++ b/src/main/java/org/project/sohwagi/schedule/adapter/out/gpt/GptAdapter.java
@@ -38,10 +38,10 @@ public class GptAdapter implements CallGptPort {
 		String SYSTEM_MESSAGE =
 			"너는 한 문장에서 일정 관련 정보를 추출하는 역할이야. "
 				+ "prompt 문장을 일정으로 등록하려는데 JSON 형태로 일정 제목, 일정 날짜로 분류해줘. 해당 값이 없으면 null 표시해줘."
-					+ "일정 날짜는 꼭 월, 일, 요일 나타내야하는데 값이 없으면 계산해서 알려줘."
+					+ "일정 날짜는 꼭 월, 일, 요일, 시각 나타내야하는데 값이 없으면 계산해서 알려줘."
 				+ "아래 양식 꼭 지켜줘. 현재 날짜는 "
 				+ LocalDateTime.now()
-				+ "이야. title, date 는 String 타입이고 date 예시: 10월 7일 월요일";
+				+ "이야. title, date 는 String 타입이고 date 예시: 2025년 4월 7일 월요일 오전 9시 00분";
 
 		List<Message> messages = new ArrayList<>();
 		messages.add(new Message("system", SYSTEM_MESSAGE));

--- a/src/main/java/org/project/sohwagi/schedule/adapter/out/gpt/GptAdapter.java
+++ b/src/main/java/org/project/sohwagi/schedule/adapter/out/gpt/GptAdapter.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.project.sohwagi.common.OutboundAdapter;
 import org.project.sohwagi.schedule.util.gpt.GPTRequest;
 import org.project.sohwagi.schedule.util.gpt.GPTResponse;
@@ -15,6 +16,7 @@ import org.project.sohwagi.schedule.application.port.out.CallGptPort;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.client.RestTemplate;
 
+@Slf4j
 @OutboundAdapter
 @RequiredArgsConstructor
 public class GptAdapter implements CallGptPort {
@@ -31,6 +33,8 @@ public class GptAdapter implements CallGptPort {
 
 	@Override
 	public ScheduleRequest callGptForTextSchedule(String prompt) throws JsonProcessingException {
+		long startTime = System.currentTimeMillis();
+
 		String SYSTEM_MESSAGE =
 			"너는 한 문장에서 일정 관련 정보를 추출하는 역할이야. "
 				+ "prompt 문장을 일정으로 등록하려는데 JSON 형태로 일정 제목, 일정 날짜로 분류해줘. 해당 값이 없으면 null 표시해줘."
@@ -59,6 +63,7 @@ public class GptAdapter implements CallGptPort {
 			.replace("```", "")
 			.trim();
 
+		log.info("OpenAI API response time : {} ms", System.currentTimeMillis() - startTime);
 		return objectMapper.readValue(jsonString,
 			ScheduleRequest.class);
 	}

--- a/src/main/java/org/project/sohwagi/schedule/adapter/out/persistence/ScheduleJpaRepository.java
+++ b/src/main/java/org/project/sohwagi/schedule/adapter/out/persistence/ScheduleJpaRepository.java
@@ -1,4 +1,4 @@
-package org.project.sohwagi.schedule.adapter.out.persistence.respository;
+package org.project.sohwagi.schedule.adapter.out.persistence;
 
 import java.util.List;
 import org.project.sohwagi.schedule.application.domain.model.Schedule;
@@ -9,5 +9,7 @@ import org.springframework.stereotype.Repository;
 public interface ScheduleJpaRepository extends JpaRepository<Schedule, Long> {
 
 	List<Schedule> findAllByUserIdOrderByMonthAscDayAsc(Long userId);
+
+	List<Schedule> findALlByUserIdAndYearAndMonth(Long userId, Integer year, Integer month);
 
 }

--- a/src/main/java/org/project/sohwagi/schedule/adapter/out/persistence/SchedulePersistenceAdapter.java
+++ b/src/main/java/org/project/sohwagi/schedule/adapter/out/persistence/SchedulePersistenceAdapter.java
@@ -3,6 +3,7 @@ package org.project.sohwagi.schedule.adapter.out.persistence;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.project.sohwagi.common.PersistenceAdapter;
 import org.project.sohwagi.schedule.adapter.out.persistence.respository.ScheduleJpaRepository;
 import org.project.sohwagi.schedule.application.domain.model.Schedule;
@@ -10,6 +11,7 @@ import org.project.sohwagi.schedule.application.port.out.DeleteSchedulePort;
 import org.project.sohwagi.schedule.application.port.out.LoadSchedulePort;
 import org.project.sohwagi.schedule.application.port.out.SaveSchedulePort;
 
+@Slf4j
 @PersistenceAdapter
 @RequiredArgsConstructor
 public class SchedulePersistenceAdapter implements SaveSchedulePort, LoadSchedulePort,
@@ -19,7 +21,12 @@ public class SchedulePersistenceAdapter implements SaveSchedulePort, LoadSchedul
 
 	@Override
 	public Schedule saveSchedule(Schedule schedule) {
-		return scheduleJpaRepository.save(schedule);
+		long startTime = System.currentTimeMillis();
+
+		Schedule savedSchedule = scheduleJpaRepository.save(schedule);
+
+		log.info("db saved schedule in {} ms", System.currentTimeMillis() - startTime);
+		return savedSchedule;
 	}
 
 	@Override

--- a/src/main/java/org/project/sohwagi/schedule/adapter/out/persistence/ScheduleRepository.java
+++ b/src/main/java/org/project/sohwagi/schedule/adapter/out/persistence/ScheduleRepository.java
@@ -1,0 +1,18 @@
+package org.project.sohwagi.schedule.adapter.out.persistence;
+
+import org.project.sohwagi.schedule.application.domain.model.Schedule;
+
+import java.util.List;
+
+public interface ScheduleRepository {
+
+    Schedule saveSchedule(Schedule schedule);
+
+    List<Schedule> loadSchedulesByUserId(Long userId);
+
+    Schedule loadScheduleById(Long scheduleId);
+
+    void deleteSchedule(Schedule schedule);
+
+    List<Schedule> findAllByUserIdAndYearAndMonth(Long userId, int year, int month);
+}

--- a/src/main/java/org/project/sohwagi/schedule/adapter/out/persistence/ScheduleRepositoryImpl.java
+++ b/src/main/java/org/project/sohwagi/schedule/adapter/out/persistence/ScheduleRepositoryImpl.java
@@ -5,17 +5,12 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.project.sohwagi.common.PersistenceAdapter;
-import org.project.sohwagi.schedule.adapter.out.persistence.respository.ScheduleJpaRepository;
 import org.project.sohwagi.schedule.application.domain.model.Schedule;
-import org.project.sohwagi.schedule.application.port.out.DeleteSchedulePort;
-import org.project.sohwagi.schedule.application.port.out.LoadSchedulePort;
-import org.project.sohwagi.schedule.application.port.out.SaveSchedulePort;
 
 @Slf4j
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class SchedulePersistenceAdapter implements SaveSchedulePort, LoadSchedulePort,
-	DeleteSchedulePort {
+public class ScheduleRepositoryImpl implements ScheduleRepository {
 
 	private final ScheduleJpaRepository scheduleJpaRepository;
 
@@ -44,4 +39,9 @@ public class SchedulePersistenceAdapter implements SaveSchedulePort, LoadSchedul
 	public void deleteSchedule(Schedule schedule) {
 		scheduleJpaRepository.delete(schedule);
 	}
+
+	@Override
+	public List<Schedule> findAllByUserIdAndYearAndMonth(Long userId, int year, int month) {
+		return scheduleJpaRepository.findALlByUserIdAndYearAndMonth(userId, year, month);
+    }
 }

--- a/src/main/java/org/project/sohwagi/schedule/application/domain/model/Schedule.java
+++ b/src/main/java/org/project/sohwagi/schedule/application/domain/model/Schedule.java
@@ -1,7 +1,9 @@
 package org.project.sohwagi.schedule.application.domain.model;
 
 import jakarta.persistence.*;
+
 import java.time.LocalDateTime;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,34 +21,53 @@ import org.project.sohwagi.schedule.adapter.in.web.request.ScheduleRequest;
 @SQLDelete(sql = "UPDATE schedule SET deleted_at = NOW() WHERE id = ?")
 public class Schedule {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-	@Column
-	private String title;
+    @Column
+    private String title;
 
-	@Column
-	private int month;
+    @Column
+    private int month;
 
-	@Column
-	private int day;
+    @Column
+    private int day;
 
-	@Column
-	private String dayOfWeek;
+    @Column
+    private String dayOfWeek;
 
-	@Column
-	private Long userId;
+    @Column
+    private Long userId;
 
-	@Column
-	@ColumnDefault("NULL")
-	private LocalDateTime deletedAt;
+    @Column
+    @ColumnDefault("NULL")
+    private LocalDateTime deletedAt;
 
-	public Schedule (String title, int month, int day, String dayOfWeek, Long userId) {
-		this.title = title;
-		this.month = month;
-		this.day = day;
-		this.dayOfWeek = dayOfWeek;
-		this.userId = userId;
-	}
+    @Column
+    private String amPm;
+
+    @Column
+    private int hour;
+
+    @Column
+    private int minute;
+
+    @Column
+    private int year;
+
+    @Column
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    public Schedule(String title, Long userId, int year, int month, int day, String dayOfWeek, String amPm, int hour, int minute) {
+        this.title = title;
+        this.month = month;
+        this.day = day;
+        this.dayOfWeek = dayOfWeek;
+        this.userId = userId;
+        this.hour = hour;
+        this.minute = minute;
+        this.year = year;
+        this.amPm = amPm;
+    }
 }

--- a/src/main/java/org/project/sohwagi/schedule/application/domain/model/YearWeekKey.java
+++ b/src/main/java/org/project/sohwagi/schedule/application/domain/model/YearWeekKey.java
@@ -1,0 +1,39 @@
+package org.project.sohwagi.schedule.application.domain.model;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.WeekFields;
+
+public record YearWeekKey(int year, int weekOfMonth, LocalDate startOfWeek) implements Comparable<YearWeekKey> {
+
+    public static YearWeekKey from(int year, int month, int day) {
+        LocalDate date = LocalDate.of(year, month, day);
+        WeekFields wf = WeekFields.of(DayOfWeek.MONDAY, 1);
+        int week = date.get(wf.weekOfMonth());
+        LocalDate start = date.with(wf.dayOfWeek(), DayOfWeek.MONDAY.getValue());
+        return new YearWeekKey(year, week, start);
+    }
+
+    public String toKoreanLabel() {
+        return switch (weekOfMonth) {
+            case 1 -> "첫째주";
+            case 2 -> "둘째주";
+            case 3 -> "셋째주";
+            case 4 -> "넷째주";
+            case 5 -> "다섯째주";
+            default -> weekOfMonth + "주차";
+        };
+    }
+
+    public String toPeriodString() {
+        String start = startOfWeek.format(DateTimeFormatter.ofPattern("MM.dd"));
+        String end = startOfWeek.plusDays(6).format(DateTimeFormatter.ofPattern("MM.dd"));
+        return start + " - " + end;
+    }
+
+    @Override
+    public int compareTo(YearWeekKey o) {
+        return 0;
+    }
+}

--- a/src/main/java/org/project/sohwagi/schedule/application/domain/model/YearWeekKey.java
+++ b/src/main/java/org/project/sohwagi/schedule/application/domain/model/YearWeekKey.java
@@ -34,6 +34,6 @@ public record YearWeekKey(int year, int weekOfMonth, LocalDate startOfWeek) impl
 
     @Override
     public int compareTo(YearWeekKey o) {
-        return 0;
+        return this.startOfWeek.compareTo(o.startOfWeek);
     }
 }

--- a/src/main/java/org/project/sohwagi/schedule/application/domain/model/YearWeekKey.java
+++ b/src/main/java/org/project/sohwagi/schedule/application/domain/model/YearWeekKey.java
@@ -15,7 +15,7 @@ public record YearWeekKey(int year, int weekOfMonth, LocalDate startOfWeek) impl
         return new YearWeekKey(year, week, start);
     }
 
-    public String toKoreanLabel() {
+    public String toLabel() {
         return switch (weekOfMonth) {
             case 1 -> "첫째주";
             case 2 -> "둘째주";

--- a/src/main/java/org/project/sohwagi/schedule/application/domain/service/ScheduleService.java
+++ b/src/main/java/org/project/sohwagi/schedule/application/domain/service/ScheduleService.java
@@ -2,6 +2,10 @@ package org.project.sohwagi.schedule.application.domain.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -13,7 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.project.sohwagi.common.UseCase;
 import org.project.sohwagi.schedule.adapter.in.web.request.ScheduleRequest;
 import org.project.sohwagi.schedule.adapter.in.web.response.ScheduleResponse;
-import org.project.sohwagi.schedule.adapter.out.persistence.respository.ScheduleJpaRepository;
+import org.project.sohwagi.schedule.adapter.out.persistence.ScheduleRepositoryImpl;
 import org.project.sohwagi.schedule.application.domain.model.Schedule;
 import org.project.sohwagi.schedule.application.domain.model.YearWeekKey;
 import org.project.sohwagi.schedule.application.port.in.command.CreateScheduleByTextCommand;
@@ -23,9 +27,6 @@ import org.project.sohwagi.schedule.application.port.in.usecase.CreateScheduleUs
 import org.project.sohwagi.schedule.application.port.in.usecase.DeleteScheduleUseCase;
 import org.project.sohwagi.schedule.application.port.in.usecase.GetScheduleUseCase;
 import org.project.sohwagi.schedule.application.port.out.CallGptPort;
-import org.project.sohwagi.schedule.application.port.out.DeleteSchedulePort;
-import org.project.sohwagi.schedule.application.port.out.LoadSchedulePort;
-import org.project.sohwagi.schedule.application.port.out.SaveSchedulePort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,10 +38,7 @@ public class ScheduleService
         implements CreateScheduleUseCase, GetScheduleUseCase, DeleteScheduleUseCase {
 
     private final CallGptPort callGptPort;
-    private final SaveSchedulePort saveSchedulePort;
-    private final LoadSchedulePort loadSchedulePort;
-    private final DeleteSchedulePort deleteSchedulePort;
-    private final ScheduleJpaRepository scheduleJpaRepository;
+    private final ScheduleRepositoryImpl scheduleRepositoryImpl;
 
     @Override
     @Transactional
@@ -52,7 +50,7 @@ public class ScheduleService
 
         Schedule schedule = parseDateString(scheduleRequest, command.userId());
 
-        Schedule savedSchedule = saveSchedulePort.saveSchedule(schedule);
+        Schedule savedSchedule = scheduleRepositoryImpl.saveSchedule(schedule);
 
         return savedSchedule.getId();
     }
@@ -60,7 +58,7 @@ public class ScheduleService
     @Override
     @Transactional(readOnly = true)
     public List<ScheduleResponse.WeekGroupedScheduleResponse> getScheduleList(GetScheduleListQuery query) {
-        List<Schedule> schedules = loadSchedulePort.loadSchedulesByUserId(query.userId());
+        List<Schedule> schedules = scheduleRepositoryImpl.findAllByUserIdAndYearAndMonth(query.userId(), query.year(), query.month());
 
         Map<YearWeekKey, List<Schedule>> grouped = schedules.stream()
                 .collect(Collectors.groupingBy(s -> YearWeekKey.from(s.getYear(), s.getMonth(), s.getDay())));
@@ -71,6 +69,10 @@ public class ScheduleService
                         entry.getKey().toLabel(),
                         entry.getKey().toPeriodString(),
                         entry.getValue().stream()
+                                .sorted(Comparator.comparing(s -> LocalDateTime.of(
+                                        LocalDate.of(query.month(), query.month(), s.getDay()),
+                                        LocalTime.of(convertTo24Hour(s.getAmPm(), s.getHour()), s.getMinute())
+                                )))
                                 .map(ScheduleResponse.ScheduleDetailResponse::new)
                                 .toList()
                 ))
@@ -81,17 +83,17 @@ public class ScheduleService
     @Override
     @Transactional
     public void deleteSchedule(DeleteScheduleCommand command) {
-        Schedule schedule = loadSchedulePort.loadScheduleById(command.scheduleId());
+        Schedule schedule = scheduleRepositoryImpl.loadScheduleById(command.scheduleId());
 
-        deleteSchedulePort.deleteSchedule(schedule);
+        scheduleRepositoryImpl.deleteSchedule(schedule);
     }
 
     @Transactional
     public void deleteScheduleByUserRevoke(Long userId) {
-        List<Schedule> schedules = scheduleJpaRepository.findAllByUserIdOrderByMonthAscDayAsc(userId);
+        List<Schedule> schedules = scheduleRepositoryImpl.loadSchedulesByUserId(userId);
 
         for (Schedule schedule : schedules) {
-            deleteSchedulePort.deleteSchedule(schedule);
+            scheduleRepositoryImpl.deleteSchedule(schedule);
         }
     }
 
@@ -115,6 +117,14 @@ public class ScheduleService
             return new Schedule(request.getTitle(), userId, year, month, day, dayOfWeek, amPm, hour, minute);
         } else {
             throw new IllegalArgumentException("Invalid date format: " + request.getDate());
+        }
+    }
+
+    private int convertTo24Hour(String amPm, int hour) {
+        if ("오전".equals(amPm)) {
+            return hour == 12 ? 0 : hour;
+        } else {
+            return hour == 12 ? 12 : hour + 12;
         }
     }
 

--- a/src/main/java/org/project/sohwagi/schedule/application/domain/service/ScheduleService.java
+++ b/src/main/java/org/project/sohwagi/schedule/application/domain/service/ScheduleService.java
@@ -54,9 +54,10 @@ public class ScheduleService
 
 	@Override
 	@Transactional(readOnly = true)
-	public List<ScheduleResponse> getScheduleList(GetScheduleListQuery query) {
+	public List<ScheduleResponse.ScheduleDetailResponse> getScheduleList(GetScheduleListQuery query) {
 		List<Schedule> schedules = loadSchedulePort.loadSchedulesByUserId(query.userId());
-		return schedules.stream().map(ScheduleResponse::new).toList();
+		return schedules.stream().map(ScheduleResponse.ScheduleDetailResponse::new
+		).toList();
 	}
 
 

--- a/src/main/java/org/project/sohwagi/schedule/application/domain/service/ScheduleService.java
+++ b/src/main/java/org/project/sohwagi/schedule/application/domain/service/ScheduleService.java
@@ -3,8 +3,10 @@ package org.project.sohwagi.schedule.application.domain.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,6 +15,7 @@ import org.project.sohwagi.schedule.adapter.in.web.request.ScheduleRequest;
 import org.project.sohwagi.schedule.adapter.in.web.response.ScheduleResponse;
 import org.project.sohwagi.schedule.adapter.out.persistence.respository.ScheduleJpaRepository;
 import org.project.sohwagi.schedule.application.domain.model.Schedule;
+import org.project.sohwagi.schedule.application.domain.model.YearWeekKey;
 import org.project.sohwagi.schedule.application.port.in.command.CreateScheduleByTextCommand;
 import org.project.sohwagi.schedule.application.port.in.command.DeleteScheduleCommand;
 import org.project.sohwagi.schedule.application.port.in.query.GetScheduleListQuery;
@@ -56,10 +59,22 @@ public class ScheduleService
 
     @Override
     @Transactional(readOnly = true)
-    public List<ScheduleResponse.ScheduleDetailResponse> getScheduleList(GetScheduleListQuery query) {
+    public List<ScheduleResponse.WeekGroupedScheduleResponse> getScheduleList(GetScheduleListQuery query) {
         List<Schedule> schedules = loadSchedulePort.loadSchedulesByUserId(query.userId());
-        return schedules.stream().map(ScheduleResponse.ScheduleDetailResponse::new
-        ).toList();
+
+        Map<YearWeekKey, List<Schedule>> grouped = schedules.stream()
+                .collect(Collectors.groupingBy(s -> YearWeekKey.from(s.getYear(), s.getMonth(), s.getDay())));
+
+        return grouped.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(entry -> new ScheduleResponse.WeekGroupedScheduleResponse(
+                        entry.getKey().toLabel(),
+                        entry.getKey().toPeriodString(),
+                        entry.getValue().stream()
+                                .map(ScheduleResponse.ScheduleDetailResponse::new)
+                                .toList()
+                ))
+                .toList();
     }
 
 

--- a/src/main/java/org/project/sohwagi/schedule/application/domain/service/ScheduleService.java
+++ b/src/main/java/org/project/sohwagi/schedule/application/domain/service/ScheduleService.java
@@ -70,7 +70,7 @@ public class ScheduleService
                         entry.getKey().toPeriodString(),
                         entry.getValue().stream()
                                 .sorted(Comparator.comparing(s -> LocalDateTime.of(
-                                        LocalDate.of(query.month(), query.month(), s.getDay()),
+                                        LocalDate.of(query.year(), query.month(), s.getDay()),
                                         LocalTime.of(convertTo24Hour(s.getAmPm(), s.getHour()), s.getMinute())
                                 )))
                                 .map(ScheduleResponse.ScheduleDetailResponse::new)

--- a/src/main/java/org/project/sohwagi/schedule/application/domain/service/ScheduleService.java
+++ b/src/main/java/org/project/sohwagi/schedule/application/domain/service/ScheduleService.java
@@ -1,9 +1,11 @@
 package org.project.sohwagi.schedule.application.domain.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.project.sohwagi.common.UseCase;
@@ -29,72 +31,76 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class ScheduleService
-	implements CreateScheduleUseCase, GetScheduleUseCase, DeleteScheduleUseCase {
+        implements CreateScheduleUseCase, GetScheduleUseCase, DeleteScheduleUseCase {
 
-	private final CallGptPort callGptPort;
-	private final SaveSchedulePort saveSchedulePort;
-	private final LoadSchedulePort loadSchedulePort;
-	private final DeleteSchedulePort deleteSchedulePort;
-	private final ScheduleJpaRepository scheduleJpaRepository;
+    private final CallGptPort callGptPort;
+    private final SaveSchedulePort saveSchedulePort;
+    private final LoadSchedulePort loadSchedulePort;
+    private final DeleteSchedulePort deleteSchedulePort;
+    private final ScheduleJpaRepository scheduleJpaRepository;
 
-	@Override
-	@Transactional
-	public Long createScheduleByText(CreateScheduleByTextCommand command)
-		throws JsonProcessingException {
-		log.info("Create schedule by text 시작");
+    @Override
+    @Transactional
+    public Long createScheduleByText(CreateScheduleByTextCommand command)
+            throws JsonProcessingException {
+        log.info("Create schedule by text 시작");
 
-		ScheduleRequest scheduleRequest = callGptPort.callGptForTextSchedule(command.text());
+        ScheduleRequest scheduleRequest = callGptPort.callGptForTextSchedule(command.text());
 
-		Schedule schedule = parseDateString(scheduleRequest, command.userId());
+        Schedule schedule = parseDateString(scheduleRequest, command.userId());
 
-		Schedule savedSchedule = saveSchedulePort.saveSchedule(schedule);
+        Schedule savedSchedule = saveSchedulePort.saveSchedule(schedule);
 
-		return savedSchedule.getId();
-	}
+        return savedSchedule.getId();
+    }
 
-	@Override
-	@Transactional(readOnly = true)
-	public List<ScheduleResponse.ScheduleDetailResponse> getScheduleList(GetScheduleListQuery query) {
-		List<Schedule> schedules = loadSchedulePort.loadSchedulesByUserId(query.userId());
-		return schedules.stream().map(ScheduleResponse.ScheduleDetailResponse::new
-		).toList();
-	}
+    @Override
+    @Transactional(readOnly = true)
+    public List<ScheduleResponse.ScheduleDetailResponse> getScheduleList(GetScheduleListQuery query) {
+        List<Schedule> schedules = loadSchedulePort.loadSchedulesByUserId(query.userId());
+        return schedules.stream().map(ScheduleResponse.ScheduleDetailResponse::new
+        ).toList();
+    }
 
 
-	@Override
-	@Transactional
-	public void deleteSchedule(DeleteScheduleCommand command) {
-		Schedule schedule = loadSchedulePort.loadScheduleById(command.scheduleId());
+    @Override
+    @Transactional
+    public void deleteSchedule(DeleteScheduleCommand command) {
+        Schedule schedule = loadSchedulePort.loadScheduleById(command.scheduleId());
 
-		deleteSchedulePort.deleteSchedule(schedule);
-	}
+        deleteSchedulePort.deleteSchedule(schedule);
+    }
 
-	@Transactional
-	public void deleteScheduleByUserRevoke(Long userId) {
-		List<Schedule> schedules = scheduleJpaRepository.findAllByUserIdOrderByMonthAscDayAsc(userId);
+    @Transactional
+    public void deleteScheduleByUserRevoke(Long userId) {
+        List<Schedule> schedules = scheduleJpaRepository.findAllByUserIdOrderByMonthAscDayAsc(userId);
 
-		for(Schedule schedule : schedules){
-			deleteSchedulePort.deleteSchedule(schedule);
-		}
-	}
+        for (Schedule schedule : schedules) {
+            deleteSchedulePort.deleteSchedule(schedule);
+        }
+    }
 
-	private Schedule parseDateString(ScheduleRequest request, Long userId) {
-		log.info(request.getDate());
-		long startTime = System.currentTimeMillis();
+    private Schedule parseDateString(ScheduleRequest request, Long userId) {
+        log.info(request.getDate());
+        long startTime = System.currentTimeMillis();
 
-		Pattern pattern = Pattern.compile("(\\d{1,2})월 (\\d{1,2})일 (\\S+)");
-		Matcher matcher = pattern.matcher(request.getDate());
+        Pattern pattern = Pattern.compile("(\\d{4})년 (\\d{1,2})월 (\\d{1,2})일 (\\S+) (오전|오후) (\\d{1,2})시 (\\d{2})분");
+        Matcher matcher = pattern.matcher(request.getDate());
 
-		if (matcher.matches()) {
-			int month = Integer.parseInt(matcher.group(1));
-			int day = Integer.parseInt(matcher.group(2));
-			String dayOfWeek = matcher.group(3);
+        if (matcher.matches()) {
+            int year = Integer.parseInt(matcher.group(1));
+            int month = Integer.parseInt(matcher.group(2));
+            int day = Integer.parseInt(matcher.group(3));
+            String dayOfWeek = matcher.group(4);
+            String amPm = matcher.group(5);
+            int hour = Integer.parseInt(matcher.group(6));
+            int minute = Integer.parseInt(matcher.group(7));
 
-			log.info("parseDateString proceeds in {} ms", System.currentTimeMillis() - startTime);
-			return new Schedule(request.getTitle(), month, day, dayOfWeek, userId);
-		} else {
-			throw new IllegalArgumentException("Invalid date format: " + request.getDate());
-		}
-	}
+            log.info("parseDateString proceeds in {} ms", System.currentTimeMillis() - startTime);
+            return new Schedule(request.getTitle(), userId, year, month, day, dayOfWeek, amPm, hour, minute);
+        } else {
+            throw new IllegalArgumentException("Invalid date format: " + request.getDate());
+        }
+    }
 
 }

--- a/src/main/java/org/project/sohwagi/schedule/application/domain/service/ScheduleService.java
+++ b/src/main/java/org/project/sohwagi/schedule/application/domain/service/ScheduleService.java
@@ -41,6 +41,8 @@ public class ScheduleService
 	@Transactional
 	public Long createScheduleByText(CreateScheduleByTextCommand command)
 		throws JsonProcessingException {
+		log.info("Create schedule by text 시작");
+
 		ScheduleRequest scheduleRequest = callGptPort.callGptForTextSchedule(command.text());
 
 		Schedule schedule = parseDateString(scheduleRequest, command.userId());
@@ -77,6 +79,7 @@ public class ScheduleService
 
 	private Schedule parseDateString(ScheduleRequest request, Long userId) {
 		log.info(request.getDate());
+		long startTime = System.currentTimeMillis();
 
 		Pattern pattern = Pattern.compile("(\\d{1,2})월 (\\d{1,2})일 (\\S+)");
 		Matcher matcher = pattern.matcher(request.getDate());
@@ -86,6 +89,7 @@ public class ScheduleService
 			int day = Integer.parseInt(matcher.group(2));
 			String dayOfWeek = matcher.group(3);
 
+			log.info("parseDateString proceeds in {} ms", System.currentTimeMillis() - startTime);
 			return new Schedule(request.getTitle(), month, day, dayOfWeek, userId);
 		} else {
 			throw new IllegalArgumentException("Invalid date format: " + request.getDate());

--- a/src/main/java/org/project/sohwagi/schedule/application/port/in/query/GetScheduleListQuery.java
+++ b/src/main/java/org/project/sohwagi/schedule/application/port/in/query/GetScheduleListQuery.java
@@ -7,14 +7,8 @@ import lombok.Builder;
 
 public record GetScheduleListQuery(
 	@NotNull(message = "userId is required")
-	Long userId
+	Long userId,
+	int year,
+	int month
 ) {
-	@Builder
-	public GetScheduleListQuery(
-		Long userId
-	) {
-		this.userId = userId;
-		validate(this);
-	}
-
 }

--- a/src/main/java/org/project/sohwagi/schedule/application/port/in/usecase/GetScheduleUseCase.java
+++ b/src/main/java/org/project/sohwagi/schedule/application/port/in/usecase/GetScheduleUseCase.java
@@ -6,6 +6,6 @@ import org.project.sohwagi.schedule.application.port.in.query.GetScheduleListQue
 
 public interface GetScheduleUseCase {
 
-	List<ScheduleResponse> getScheduleList(GetScheduleListQuery query);
+	List<ScheduleResponse.ScheduleDetailResponse> getScheduleList(GetScheduleListQuery query);
 
 }

--- a/src/main/java/org/project/sohwagi/schedule/application/port/in/usecase/GetScheduleUseCase.java
+++ b/src/main/java/org/project/sohwagi/schedule/application/port/in/usecase/GetScheduleUseCase.java
@@ -6,6 +6,6 @@ import org.project.sohwagi.schedule.application.port.in.query.GetScheduleListQue
 
 public interface GetScheduleUseCase {
 
-	List<ScheduleResponse.ScheduleDetailResponse> getScheduleList(GetScheduleListQuery query);
+	List<ScheduleResponse.WeekGroupedScheduleResponse> getScheduleList(GetScheduleListQuery query);
 
 }

--- a/src/main/java/org/project/sohwagi/token/TokenService.java
+++ b/src/main/java/org/project/sohwagi/token/TokenService.java
@@ -7,12 +7,10 @@ import org.springframework.stereotype.Service;
 @Service
 public class TokenService {
 
-  private final JwtUtil jwtUtil;
   private final TokenRepository tokenRepository;
 
   public TokenService(TokenRepository tokenRepository, JwtUtil jwtUtil){
     this.tokenRepository = tokenRepository;
-    this.jwtUtil = jwtUtil;
   }
 
   public String saveToken(RefreshTokenCommand command){

--- a/src/main/resources/db/migration/V2__add_time_fields_to_schedule.sql
+++ b/src/main/resources/db/migration/V2__add_time_fields_to_schedule.sql
@@ -1,0 +1,12 @@
+ALTER TABLE schedule ADD COLUMN year INT;
+ALTER TABLE schedule ADD COLUMN am_pm VARCHAR(10);
+ALTER TABLE schedule ADD COLUMN hour INT;
+ALTER TABLE schedule ADD COLUMN minute INT;
+ALTER TABLE schedule ADD COLUMN created_at DATETIME DEFAULT CURRENT_TIMESTAMP;
+
+UPDATE schedule
+SET year = 2025,
+    am_pm = '오전',
+    hour = 0,
+    minute = 0
+WHERE year IS NULL;


### PR DESCRIPTION
## 📄 작업 내역
- 기존 flat한 일정 응답 구조를 주차 기준으로 그룹화된 구조로 리팩토링
- 응답 DTO 구조를 ScheduleDetailResponse, WeekGroupedScheduleResponse로 재정의
- 각 일정에 time 필드(예: "오전 7시 30분")를 추가
- 응답을 주차별로 그룹화
   - week : 첫째주, 둘째주 형식
   - periodOfWeek : 03.03 - 03.09 형식
- 주차 라벨(첫째주, 둘째주 등)과 주간 날짜 범위(periodOfWeek: "04.07 - 04.13") 계산 로직 추가
- 일정들을 LocalDateTime 기준으로 정렬하여 동일 주차 내에서도 시간 순으로 정렬되도록 개선
- YearWeekKey VO 도입: 주차 계산, 정렬, 라벨링 책임 분리
- `Schedule` 테이블 변경에 따른 마이그레이션 스크립트 추가

## 🗣️ 의사결정 흐름
- 주차 단위로 일정을 그룹화하면 클라이언트 UI가 더 명확하고 직관적으로 구성될 수 있음
- Schedule 도메인 자체에 날짜+시간 정보가 분리되어 있으므로, 정렬은 LocalDateTime.of(...)로 명시적으로 구성
- YearWeekKey를 별도의 VO로 정의하여 주차 계산, 라벨 변환, 정렬 책임을 응집도 있게 분리

## 🔗 관련 이슈
Closes #48 