### PR TITLE
일정 체크 api 구현 및 특정 날짜 일정 조회 api 수정

### DIFF
--- a/src/main/java/org/project/sohwagi/application/cmd/ScheduleCommand.java
+++ b/src/main/java/org/project/sohwagi/application/cmd/ScheduleCommand.java
@@ -34,4 +34,6 @@ public class ScheduleCommand {
       String date,
       Long userId
   ) { }
+
+  public record ScheduleCheckCommand(Long userId) { }
 }

--- a/src/main/java/org/project/sohwagi/application/facade/ScheduleFacadeService.java
+++ b/src/main/java/org/project/sohwagi/application/facade/ScheduleFacadeService.java
@@ -10,9 +10,10 @@ import org.project.sohwagi.application.cmd.ScheduleCommand.ScheduleCountCommand;
 import org.project.sohwagi.application.cmd.ScheduleCommand.ScheduleCreateByTextCommand;
 import org.project.sohwagi.application.cmd.ScheduleCommand.ScheduleCreateCommand;
 import org.project.sohwagi.application.cmd.ScheduleCommand.SchedulesGetOnDate;
+import org.project.sohwagi.application.info.ScheduleInfo.ScheduleCountsInfo;
+import org.project.sohwagi.application.info.ScheduleInfo.ScheduleDetailsInfo;
 import org.project.sohwagi.application.service.ScheduleService;
-import org.project.sohwagi.application.info.ScheduleInfo;
-import org.project.sohwagi.application.info.ScheduleInfo.ScheduleDetail;
+import org.project.sohwagi.application.info.ScheduleInfo.ScheduleDetailInfo;
 import org.project.sohwagi.infra.llm.LlmClient;
 import org.project.sohwagi.infra.llm.LlmResult.ExtractedScheduleInformation;
 import org.springframework.stereotype.Service;
@@ -24,16 +25,16 @@ public class ScheduleFacadeService {
   private final LlmClient llmClient;
   private final ScheduleService scheduleService;
 
-  public ScheduleInfo.ScheduleCounts getScheduleCounts(ScheduleCountCommand cmd) {
+  public ScheduleCountsInfo getScheduleCounts(ScheduleCountCommand cmd) {
     Map<String, Integer> result = scheduleService.getScheduleCounts(cmd);
 
-    return new ScheduleInfo.ScheduleCounts(result);
+    return new ScheduleCountsInfo(result);
   }
 
-  public ScheduleInfo.ScheduleDetails getSchedulesOnDate(SchedulesGetOnDate cmd) {
-    List<ScheduleDetail> scheduleDetailList = scheduleService.getSchedulesOnDate(cmd);
+  public ScheduleDetailsInfo getSchedulesOnDate(SchedulesGetOnDate cmd) {
+    List<ScheduleDetailInfo> scheduleDetailInfoList = scheduleService.getSchedulesOnDate(cmd);
 
-    return new ScheduleInfo.ScheduleDetails(scheduleDetailList);
+    return new ScheduleDetailsInfo(scheduleDetailInfoList);
   }
 
   @Transactional

--- a/src/main/java/org/project/sohwagi/application/facade/ScheduleFacadeService.java
+++ b/src/main/java/org/project/sohwagi/application/facade/ScheduleFacadeService.java
@@ -5,7 +5,7 @@ import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.project.sohwagi.application.cmd.ScheduleCommand;
+import org.project.sohwagi.application.cmd.ScheduleCommand.ScheduleCheckCommand;
 import org.project.sohwagi.application.cmd.ScheduleCommand.ScheduleCountCommand;
 import org.project.sohwagi.application.cmd.ScheduleCommand.ScheduleCreateByTextCommand;
 import org.project.sohwagi.application.cmd.ScheduleCommand.ScheduleCreateCommand;
@@ -48,5 +48,10 @@ public class ScheduleFacadeService {
             cmd.userId()
         )
     );
+  }
+
+  @Transactional
+  public void checkSchedule(ScheduleCheckCommand cmd) {
+    scheduleService.checkSchedule(cmd);
   }
 }

--- a/src/main/java/org/project/sohwagi/application/info/ScheduleInfo.java
+++ b/src/main/java/org/project/sohwagi/application/info/ScheduleInfo.java
@@ -5,13 +5,13 @@ import java.util.Map;
 
 public class ScheduleInfo {
 
-  public record ScheduleCounts(
+  public record ScheduleCountsInfo(
       Map<String, Integer> scheduleCounts
   ) {
 
   }
 
-  public record ScheduleDetail(
+  public record ScheduleDetailInfo(
       Long scheduleId,
       String title,
       String amPm,
@@ -19,8 +19,10 @@ public class ScheduleInfo {
       int minute
   ) {}
 
-  public record ScheduleDetails(
-      List<ScheduleDetail> schedules
+  public record ScheduleDetailsInfo(
+      List<ScheduleDetailInfo> schedules
   ) {}
+
+
 
 }

--- a/src/main/java/org/project/sohwagi/application/info/ScheduleInfo.java
+++ b/src/main/java/org/project/sohwagi/application/info/ScheduleInfo.java
@@ -16,13 +16,12 @@ public class ScheduleInfo {
       String title,
       String amPm,
       int hour,
-      int minute
+      int minute,
+      boolean checked
   ) {}
 
   public record ScheduleDetailsInfo(
       List<ScheduleDetailInfo> schedules
   ) {}
-
-
 
 }

--- a/src/main/java/org/project/sohwagi/application/service/ScheduleService.java
+++ b/src/main/java/org/project/sohwagi/application/service/ScheduleService.java
@@ -19,7 +19,7 @@ import org.project.sohwagi.domain.ScheduleRepository;
 import org.project.sohwagi.application.cmd.ScheduleCommand.ScheduleCountCommand;
 import org.project.sohwagi.application.cmd.ScheduleCommand.SchedulesGetOnDate;
 import org.project.sohwagi.domain.Schedule;
-import org.project.sohwagi.application.info.ScheduleInfo.ScheduleDetail;
+import org.project.sohwagi.application.info.ScheduleInfo.ScheduleDetailInfo;
 import org.project.sohwagi.application.cmd.DeleteScheduleCommand;
 import org.project.sohwagi.schedule.application.port.in.usecase.DeleteScheduleUseCase;
 import org.springframework.stereotype.Service;
@@ -113,13 +113,13 @@ public class ScheduleService
         ));
   }
 
-  public List<ScheduleDetail> getSchedulesOnDate(SchedulesGetOnDate cmd) {
+  public List<ScheduleDetailInfo> getSchedulesOnDate(SchedulesGetOnDate cmd) {
     List<Schedule> schedules = scheduleRepository.findAllByUserIdAndYearAndMonthAndDay(cmd.userId(),
         cmd.year(),
         cmd.month(), cmd.day());
 
     return schedules.stream().map(
-            s -> new ScheduleDetail(s.getId(), s.getTitle(), s.getAmPm(), s.getHour(), s.getMinute()))
+            s -> new ScheduleDetailInfo(s.getId(), s.getTitle(), s.getAmPm(), s.getHour(), s.getMinute()))
         .toList();
   }
 

--- a/src/main/java/org/project/sohwagi/application/service/ScheduleService.java
+++ b/src/main/java/org/project/sohwagi/application/service/ScheduleService.java
@@ -1,7 +1,5 @@
 package org.project.sohwagi.application.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.LinkedHashMap;
@@ -14,18 +12,15 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.project.sohwagi.application.cmd.ScheduleCommand.ScheduleCreateByTextCommand;
+import org.project.sohwagi.application.cmd.ScheduleCommand.ScheduleCheckCommand;
 import org.project.sohwagi.application.cmd.ScheduleCommand.ScheduleCreateCommand;
 import org.project.sohwagi.common.UseCase;
-import org.project.sohwagi.presentation.req.ScheduleRequest;
 import org.project.sohwagi.domain.ScheduleRepository;
 import org.project.sohwagi.application.cmd.ScheduleCommand.ScheduleCountCommand;
 import org.project.sohwagi.application.cmd.ScheduleCommand.SchedulesGetOnDate;
 import org.project.sohwagi.domain.Schedule;
 import org.project.sohwagi.application.info.ScheduleInfo.ScheduleDetail;
-import org.project.sohwagi.application.cmd.CreateScheduleByTextCommand;
 import org.project.sohwagi.application.cmd.DeleteScheduleCommand;
-import org.project.sohwagi.schedule.application.port.in.usecase.CreateScheduleUseCase;
 import org.project.sohwagi.schedule.application.port.in.usecase.DeleteScheduleUseCase;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -130,5 +125,11 @@ public class ScheduleService
 
   public List<Schedule> findTodaySchedules(LocalDate today) {
     return scheduleRepository.findTodaySchedules(today) ;
+  }
+
+  public void checkSchedule(ScheduleCheckCommand cmd) {
+    Schedule schedule = scheduleRepository.findScheduleById(cmd.userId());
+
+    schedule.checkSchedule(schedule.getChecked());
   }
 }

--- a/src/main/java/org/project/sohwagi/application/service/ScheduleService.java
+++ b/src/main/java/org/project/sohwagi/application/service/ScheduleService.java
@@ -119,7 +119,15 @@ public class ScheduleService
         cmd.month(), cmd.day());
 
     return schedules.stream().map(
-            s -> new ScheduleDetailInfo(s.getId(), s.getTitle(), s.getAmPm(), s.getHour(), s.getMinute()))
+            s -> new ScheduleDetailInfo(
+                s.getId(),
+                s.getTitle(),
+                s.getAmPm(),
+                s.getHour(),
+                s.getMinute(),
+                s.getChecked()
+            )
+        )
         .toList();
   }
 

--- a/src/main/java/org/project/sohwagi/domain/Schedule.java
+++ b/src/main/java/org/project/sohwagi/domain/Schedule.java
@@ -84,6 +84,6 @@ public class Schedule {
 	}
 
 	public void checkSchedule(boolean checked) {
-		this.checked = checked;
+		this.checked =!checked;
 	}
 }

--- a/src/main/java/org/project/sohwagi/domain/Schedule.java
+++ b/src/main/java/org/project/sohwagi/domain/Schedule.java
@@ -58,7 +58,19 @@ public class Schedule {
 	@Column
 	private LocalDateTime createdAt = LocalDateTime.now();
 
-	public Schedule(String title, Long userId, int year, int month, int day, String dayOfWeek, String amPm, int hour, int minute) {
+	@Column
+	private Boolean checked;
+
+	public Schedule(
+			String title,
+			Long userId,
+			int year,
+			int month,
+			int day,
+			String dayOfWeek,
+			String amPm,
+			int hour,
+			int minute) {
 		this.title = title;
 		this.month = month;
 		this.day = day;
@@ -68,5 +80,10 @@ public class Schedule {
 		this.minute = minute;
 		this.year = year;
 		this.amPm = amPm;
+		this.checked = false;
+	}
+
+	public void checkSchedule(boolean checked) {
+		this.checked = checked;
 	}
 }

--- a/src/main/java/org/project/sohwagi/domain/ScheduleRepository.java
+++ b/src/main/java/org/project/sohwagi/domain/ScheduleRepository.java
@@ -24,4 +24,6 @@ public interface ScheduleRepository {
     List<Schedule> findAllByUserIdAndYearAndMonthAndDay(Long userId, int year, int month, int day);
 
     List<Schedule> findTodaySchedules(LocalDate today);
+
+    Schedule findScheduleById(Long scheduleId);
 }

--- a/src/main/java/org/project/sohwagi/infra/repository/ScheduleRepositoryImpl.java
+++ b/src/main/java/org/project/sohwagi/infra/repository/ScheduleRepositoryImpl.java
@@ -70,4 +70,11 @@ public class ScheduleRepositoryImpl implements ScheduleRepository {
 		return scheduleJpaRepository.findAllByYearAndMonthAndDay(today.getYear(), today.getMonthValue(),
 				today.getDayOfMonth());
 	}
+
+	@Override
+	public Schedule findScheduleById(Long scheduleId) {
+		return scheduleJpaRepository.findById(scheduleId).orElseThrow(
+				() -> new EntityNotFoundException("해당 일정은 존재하지 않습니다.")
+		);
+	}
 }

--- a/src/main/java/org/project/sohwagi/presentation/controller/ScheduleController.java
+++ b/src/main/java/org/project/sohwagi/presentation/controller/ScheduleController.java
@@ -9,15 +9,15 @@ import org.project.sohwagi.application.cmd.ScheduleCommand.ScheduleCheckCommand;
 import org.project.sohwagi.application.cmd.ScheduleCommand.ScheduleCountCommand;
 import org.project.sohwagi.application.cmd.ScheduleCommand.ScheduleCreateByTextCommand;
 import org.project.sohwagi.application.cmd.ScheduleCommand.SchedulesGetOnDate;
+import org.project.sohwagi.application.info.ScheduleInfo.ScheduleCountsInfo;
+import org.project.sohwagi.application.info.ScheduleInfo.ScheduleDetailsInfo;
 import org.project.sohwagi.common.UserInfo;
 import org.project.sohwagi.presentation.req.ScheduleRequest.ScheduleCreateByTextRequest;
 import org.project.sohwagi.presentation.res.ScheduleResponse;
 import org.project.sohwagi.presentation.res.ScheduleResponse.V1_GetList;
 import org.project.sohwagi.presentation.res.ScheduleResponse.V1_GetScheduleCount;
 import org.project.sohwagi.application.facade.ScheduleFacadeService;
-import org.project.sohwagi.application.info.ScheduleInfo;
 import org.project.sohwagi.application.cmd.DeleteScheduleCommand;
-import org.project.sohwagi.schedule.application.port.in.usecase.CreateScheduleUseCase;
 import org.project.sohwagi.schedule.application.port.in.usecase.DeleteScheduleUseCase;
 import org.project.sohwagi.domain.UserDetails;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -83,7 +83,7 @@ public class ScheduleController {
       LocalDate endDate,
       @UserInfo UserDetails userDetails) {
 
-    ScheduleInfo.ScheduleCounts info = scheduleFacadeService.getScheduleCounts(
+    ScheduleCountsInfo info = scheduleFacadeService.getScheduleCounts(
         ScheduleCountCommand.from(userDetails.id(), startDate, endDate)
     );
 
@@ -95,7 +95,7 @@ public class ScheduleController {
       @RequestParam @NotNull int year, @RequestParam @NotNull int month,
       @RequestParam @NotNull int day, @UserInfo UserDetails userDetails
   ) {
-    ScheduleInfo.ScheduleDetails info = scheduleFacadeService.getSchedulesOnDate(
+    ScheduleDetailsInfo info = scheduleFacadeService.getSchedulesOnDate(
         SchedulesGetOnDate.from(year, month, day, userDetails.id())
     );
 

--- a/src/main/java/org/project/sohwagi/presentation/controller/ScheduleController.java
+++ b/src/main/java/org/project/sohwagi/presentation/controller/ScheduleController.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import java.net.URI;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import org.project.sohwagi.application.cmd.ScheduleCommand.ScheduleCheckCommand;
 import org.project.sohwagi.application.cmd.ScheduleCommand.ScheduleCountCommand;
 import org.project.sohwagi.application.cmd.ScheduleCommand.ScheduleCreateByTextCommand;
 import org.project.sohwagi.application.cmd.ScheduleCommand.SchedulesGetOnDate;
@@ -99,6 +100,13 @@ public class ScheduleController {
     );
 
     return ResponseEntity.ok().body(ScheduleResponse.V1_GetList.from(info));
+  }
+
+  @PostMapping("/{scheduleId}/actions/toggle-checked")
+  public ResponseEntity<Void> checkSchedule(@PathVariable Long scheduleId) {
+    scheduleFacadeService.checkSchedule(new ScheduleCheckCommand(scheduleId));
+
+    return ResponseEntity.ok().build();
   }
 
 }

--- a/src/main/java/org/project/sohwagi/presentation/controller/ScheduleController.java
+++ b/src/main/java/org/project/sohwagi/presentation/controller/ScheduleController.java
@@ -14,7 +14,7 @@ import org.project.sohwagi.application.info.ScheduleInfo.ScheduleDetailsInfo;
 import org.project.sohwagi.common.UserInfo;
 import org.project.sohwagi.presentation.req.ScheduleRequest.ScheduleCreateByTextRequest;
 import org.project.sohwagi.presentation.res.ScheduleResponse;
-import org.project.sohwagi.presentation.res.ScheduleResponse.V1_GetList;
+import org.project.sohwagi.presentation.res.ScheduleResponse.ScheduleGetListResponse;
 import org.project.sohwagi.presentation.res.ScheduleResponse.V1_GetScheduleCount;
 import org.project.sohwagi.application.facade.ScheduleFacadeService;
 import org.project.sohwagi.application.cmd.DeleteScheduleCommand;
@@ -91,7 +91,7 @@ public class ScheduleController {
   }
 
   @GetMapping()
-  public ResponseEntity<V1_GetList> getSchedulesOnDate(
+  public ResponseEntity<ScheduleGetListResponse> getSchedulesOnDate(
       @RequestParam @NotNull int year, @RequestParam @NotNull int month,
       @RequestParam @NotNull int day, @UserInfo UserDetails userDetails
   ) {
@@ -99,7 +99,7 @@ public class ScheduleController {
         SchedulesGetOnDate.from(year, month, day, userDetails.id())
     );
 
-    return ResponseEntity.ok().body(ScheduleResponse.V1_GetList.from(info));
+    return ResponseEntity.ok().body(ScheduleGetListResponse.from(info));
   }
 
   @PostMapping("/{scheduleId}/actions/toggle-checked")

--- a/src/main/java/org/project/sohwagi/presentation/res/ScheduleResponse.java
+++ b/src/main/java/org/project/sohwagi/presentation/res/ScheduleResponse.java
@@ -61,13 +61,16 @@ public class ScheduleResponse {
   public record V1_Get(
       Long scheduleId,
       String title,
-      String time
+      String time,
+      boolean checked
   ) {
 
     public static V1_Get from(ScheduleDetailInfo info) {
-      return new V1_Get(info.scheduleId(), info.title(),
-          info.amPm() + " " + info.hour() + "시 " + String.format("%02d",
-              info.minute()) + "분");
+      return new V1_Get(
+          info.scheduleId(),
+          info.title(),
+          info.amPm() + " " + info.hour() + "시 " + String.format("%02d", info.minute()) + "분",
+          info.checked());
     }
   }
 

--- a/src/main/java/org/project/sohwagi/presentation/res/ScheduleResponse.java
+++ b/src/main/java/org/project/sohwagi/presentation/res/ScheduleResponse.java
@@ -4,10 +4,12 @@ import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.project.sohwagi.application.info.ScheduleInfo.ScheduleCountsInfo;
+import org.project.sohwagi.application.info.ScheduleInfo.ScheduleDetailInfo;
+import org.project.sohwagi.application.info.ScheduleInfo.ScheduleDetailsInfo;
 import org.project.sohwagi.domain.Schedule;
 
 import java.util.List;
-import org.project.sohwagi.application.info.ScheduleInfo;
 
 public class ScheduleResponse {
 
@@ -51,7 +53,7 @@ public class ScheduleResponse {
 
   public record V1_GetScheduleCount(Map<String, Integer> scheduleCounts) {
 
-    public static V1_GetScheduleCount from(ScheduleInfo.ScheduleCounts info) {
+    public static V1_GetScheduleCount from(ScheduleCountsInfo info) {
       return new V1_GetScheduleCount(info.scheduleCounts());
     }
   }
@@ -62,7 +64,7 @@ public class ScheduleResponse {
       String time
   ) {
 
-    public static V1_Get from(ScheduleInfo.ScheduleDetail info) {
+    public static V1_Get from(ScheduleDetailInfo info) {
       return new V1_Get(info.scheduleId(), info.title(),
           info.amPm() + " " + info.hour() + "시 " + String.format("%02d",
               info.minute()) + "분");
@@ -73,7 +75,7 @@ public class ScheduleResponse {
       List<V1_Get> schedules
   ) {
 
-    public static V1_GetList from(ScheduleInfo.ScheduleDetails info) {
+    public static V1_GetList from(ScheduleDetailsInfo info) {
       return new V1_GetList(
           info.schedules().stream().map(V1_Get::from).toList()
       );

--- a/src/main/java/org/project/sohwagi/presentation/res/ScheduleResponse.java
+++ b/src/main/java/org/project/sohwagi/presentation/res/ScheduleResponse.java
@@ -58,15 +58,15 @@ public class ScheduleResponse {
     }
   }
 
-  public record V1_Get(
+  public record ScheduleGetResponse(
       Long scheduleId,
       String title,
       String time,
       boolean checked
   ) {
 
-    public static V1_Get from(ScheduleDetailInfo info) {
-      return new V1_Get(
+    public static ScheduleGetResponse from(ScheduleDetailInfo info) {
+      return new ScheduleGetResponse(
           info.scheduleId(),
           info.title(),
           info.amPm() + " " + info.hour() + "시 " + String.format("%02d", info.minute()) + "분",
@@ -74,13 +74,13 @@ public class ScheduleResponse {
     }
   }
 
-  public record V1_GetList(
-      List<V1_Get> schedules
+  public record ScheduleGetListResponse(
+      List<ScheduleGetResponse> schedules
   ) {
 
-    public static V1_GetList from(ScheduleDetailsInfo info) {
-      return new V1_GetList(
-          info.schedules().stream().map(V1_Get::from).toList()
+    public static ScheduleGetListResponse from(ScheduleDetailsInfo info) {
+      return new ScheduleGetListResponse(
+          info.schedules().stream().map(ScheduleGetResponse::from).toList()
       );
     }
   }


### PR DESCRIPTION
## 개요
일정 항목에 체크 상태(`checked`)를 부여할 수 있도록 도메인 필드를 추가하고, 해당 값을 변경할 수 있는 API 및 관련 조회 로직을 반영했습니다. 사용자는 일정을 체크하거나 해제할 수 있으며, 체크 여부는 조회 API에도 포함됩니다.

## 📄 작업 내역
- 도메인
   - `Schedule` 엔티티에 `Boolean checked` 필드 추가 (기본값 false)
   - `checkSchedule(boolean checked)` 도메인 메서드 구현 -> 내부에서 `this.checked = !checked` 처리
- 서비스 계층
   - `ScheduleCheckCommand(scheduleId)` 커맨드 정의
   - `ScheduleRepository.findScheduleById(ScheduleId)` 쿼리 메서드 추가
   - `ScheduleService.checkSchedule(cmd)`에서 일정 ID로 조회 후 `checkSchedule()` 호출
   - `ScheduleFacadeService.checkSchedule()` 메서드 추가
- 조회 api 변경
   - `ScheduleDetailInfo`, `ScheduleDetailsInfo`, `ScheduleGetResponse`, `ScheduleGetListResponse`에 `checked` 필드 추가

## 🗣️ 의사결정 흐름
- 일정의 체크 상태는 단순 터치 기반 UX와 연결되므로, 도메인 메서드에서 `this.checked = !checked`로 처리하였습니다.
   - 매 요청 시 상태를 반전시키는 방식은 프론트엔드가 명시적 상태를 관리하지 않아도 되는 점에서 효율적입니다.
   - 실제 체크 상태를 인자로 받아 저장하는 방식(`this.checked = checked`)은 향후 명시적 상태 변경이 필요한 경우 도입을 고려할 수 있습니다.
   
## 🔗 관련 이슈
Closes #72 
Closes #73 
Closes #82 