### PR TITLE
스케줄링 기반 푸시 알림 기능 추가

### DIFF
--- a/src/main/java/org/project/sohwagi/SohwagiApplication.java
+++ b/src/main/java/org/project/sohwagi/SohwagiApplication.java
@@ -2,7 +2,11 @@ package org.project.sohwagi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableAsync
+@EnableScheduling
 @SpringBootApplication
 public class SohwagiApplication {
 

--- a/src/main/java/org/project/sohwagi/application/facade/ScheduleNotificationService.java
+++ b/src/main/java/org/project/sohwagi/application/facade/ScheduleNotificationService.java
@@ -59,4 +59,16 @@ public class ScheduleNotificationService {
       firebaseMessagingClient.sendMessage(user.getFcmToken(), title, body);
     }
   }
+
+  public void sendScheduleRegistrationNotifications() throws FirebaseMessagingException {
+    LocalDate today = LocalDate.now();
+    LocalDate sevenDaysAgo = today.minusDays(6);
+    List<User> targets = userService.findUsersWithoutSchedulesInLastWeek(today, sevenDaysAgo);
+    for (User target : targets) {
+      String title = "지금 기억나는 일정 빠르게 등록하라 햄+_+";
+      String body = "메모하듯이 한 문장으로 빠르게 입력해보세요!";
+
+      firebaseMessagingClient.sendMessage(target.getFcmToken(), title, body);
+    }
+  }
 }

--- a/src/main/java/org/project/sohwagi/application/facade/ScheduleNotificationService.java
+++ b/src/main/java/org/project/sohwagi/application/facade/ScheduleNotificationService.java
@@ -39,15 +39,17 @@ public class ScheduleNotificationService {
 
     Map<Long, List<Schedule>> scheduleMap = todaySchedules.stream()
         .collect(Collectors.groupingBy(Schedule::getUserId));
+    Set<Long> userIds = scheduleMap.keySet();
+    Map<Long, User> userMap = userService.findAllUserByIdIn(userIds).stream()
+        .collect(Collectors.toMap(User::getId, user -> user));
 
     for (Map.Entry<Long, List<Schedule>> entry : scheduleMap.entrySet()) {
       Long userId = entry.getKey();
-      List<Schedule> schedules = entry.getValue();
-      User user = userService.findById(userId);
+      User user = userMap.get(userId);
       if(user.getFcmToken() == null || user.getFcmToken().isEmpty()) {
         continue;
       }
-
+      List<Schedule> schedules = entry.getValue();
       String title = String.format("오늘 일정 %d개다 햄+_+", schedules.size());
       String body = String.format(
           "오늘 %s %02d:%02d에 %s이(가) 있어요!",

--- a/src/main/java/org/project/sohwagi/application/facade/ScheduleNotificationService.java
+++ b/src/main/java/org/project/sohwagi/application/facade/ScheduleNotificationService.java
@@ -4,7 +4,9 @@ import com.google.firebase.messaging.FirebaseMessagingException;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.project.sohwagi.application.service.ScheduleService;
 import org.project.sohwagi.application.service.UserService;
 import org.project.sohwagi.domain.Schedule;
@@ -12,6 +14,7 @@ import org.project.sohwagi.domain.User;
 import org.project.sohwagi.infra.firebase.FirebaseMessagingClient;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 public class ScheduleNotificationService {
 
@@ -26,10 +29,13 @@ public class ScheduleNotificationService {
     this.userService = userService;
   }
 
-  public void notifyUsersOfTodaySchedules() throws FirebaseMessagingException {
+  public void sendDailyScheduleNotifications() throws FirebaseMessagingException {
     LocalDate today = LocalDate.now();
 
     List<Schedule> todaySchedules = scheduleService.findTodaySchedules(today);
+    if (todaySchedules.isEmpty()) {
+      return;
+    }
 
     Map<Long, List<Schedule>> scheduleMap = todaySchedules.stream()
         .collect(Collectors.groupingBy(Schedule::getUserId));
@@ -38,11 +44,17 @@ public class ScheduleNotificationService {
       Long userId = entry.getKey();
       List<Schedule> schedules = entry.getValue();
       User user = userService.findById(userId);
+      if(user.getFcmToken() == null || user.getFcmToken().isEmpty()) {
+        continue;
+      }
 
-      String title = "오늘의 일정";
-      String body = schedules.stream()
-          .map(Schedule::getTitle)
-          .collect(Collectors.joining(", "));
+      String title = String.format("오늘 일정 %d개다 햄+_+", schedules.size());
+      String body = String.format(
+          "오늘 %s %02d:%02d에 %s이(가) 있어요!",
+          schedules.get(0).getAmPm(),
+          schedules.get(0).getHour(),
+          schedules.get(0).getMinute(),
+          schedules.get(0).getTitle());
 
       firebaseMessagingClient.sendMessage(user.getFcmToken(), title, body);
     }

--- a/src/main/java/org/project/sohwagi/application/service/UserService.java
+++ b/src/main/java/org/project/sohwagi/application/service/UserService.java
@@ -2,6 +2,7 @@ package org.project.sohwagi.application.service;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.project.sohwagi.application.cmd.SaveFcmTokenCommand;
 import org.project.sohwagi.common.UseCase;
@@ -61,6 +62,10 @@ public class UserService {
         + sevenDaysAgo.getDayOfMonth();
     int endYmd = today.getYear() * 10000 + today.getMonthValue() * 100 + today.getDayOfMonth();
     return userRepository.findActiveUsersWithoutSchedulesBetweenYmd(startYmd, endYmd);
+  }
+
+  public List<User> findAllUserByIdIn(Set<Long> ids) {
+    return userRepository.findAllUserByIdIn(ids);
   }
 
   private String convertName(String name) {

--- a/src/main/java/org/project/sohwagi/application/service/UserService.java
+++ b/src/main/java/org/project/sohwagi/application/service/UserService.java
@@ -1,5 +1,7 @@
 package org.project.sohwagi.application.service;
 
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.project.sohwagi.application.cmd.SaveFcmTokenCommand;
 import org.project.sohwagi.common.UseCase;
@@ -7,6 +9,7 @@ import org.project.sohwagi.domain.User;
 import org.project.sohwagi.domain.UserDetails;
 import org.project.sohwagi.domain.UserRepository;
 import org.project.sohwagi.presentation.res.GetUserInfoRes;
+import org.springframework.cglib.core.Local;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -50,6 +53,14 @@ public class UserService {
   public User saveUser(String userName, String oauthProvider, String email) {
     User user = User.create(userName, oauthProvider, email);
     return userRepository.save(user);
+  }
+
+  public List<User> findUsersWithoutSchedulesInLastWeek(LocalDate today, LocalDate sevenDaysAgo) {
+    int startYmd = sevenDaysAgo.getYear() * 10000
+        + sevenDaysAgo.getMonthValue() * 100
+        + sevenDaysAgo.getDayOfMonth();
+    int endYmd = today.getYear() * 10000 + today.getMonthValue() * 100 + today.getDayOfMonth();
+    return userRepository.findActiveUsersWithoutSchedulesBetweenYmd(startYmd, endYmd);
   }
 
   private String convertName(String name) {

--- a/src/main/java/org/project/sohwagi/domain/UserRepository.java
+++ b/src/main/java/org/project/sohwagi/domain/UserRepository.java
@@ -2,6 +2,7 @@ package org.project.sohwagi.domain;
 
 import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
+import java.util.Set;
 import org.project.sohwagi.infra.jpa.UserJpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -38,4 +39,9 @@ public class UserRepository {
   public List<User> findActiveUsersWithoutSchedulesBetweenYmd(int startYmd, int endYmd) {
     return userJpaRepository.findActiveUsersWithoutSchedulesBetweenYmd(startYmd, endYmd);
   }
+
+  public List<User> findAllUserByIdIn(Set<Long> ids) {
+    return userJpaRepository.findAllByIdIn(ids);
+  }
+
 }

--- a/src/main/java/org/project/sohwagi/domain/UserRepository.java
+++ b/src/main/java/org/project/sohwagi/domain/UserRepository.java
@@ -1,6 +1,7 @@
 package org.project.sohwagi.domain;
 
 import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
 import org.project.sohwagi.infra.jpa.UserJpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -32,5 +33,9 @@ public class UserRepository {
 
   public User save(User user) {
     return userJpaRepository.save(user);
+  }
+
+  public List<User> findActiveUsersWithoutSchedulesBetweenYmd(int startYmd, int endYmd) {
+    return userJpaRepository.findActiveUsersWithoutSchedulesBetweenYmd(startYmd, endYmd);
   }
 }

--- a/src/main/java/org/project/sohwagi/infra/config/AsyncConfig.java
+++ b/src/main/java/org/project/sohwagi/infra/config/AsyncConfig.java
@@ -1,0 +1,21 @@
+package org.project.sohwagi.infra.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class AsyncConfig {
+
+  @Bean(name = "notificationExecutor")
+  public Executor notificationExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(10);
+    executor.setMaxPoolSize(20);
+    executor.setQueueCapacity(100);
+    executor.setThreadNamePrefix("fcm-sender-");
+    executor.initialize();
+    return executor;
+  }
+}

--- a/src/main/java/org/project/sohwagi/infra/firebase/FirebaseMessagingClient.java
+++ b/src/main/java/org/project/sohwagi/infra/firebase/FirebaseMessagingClient.java
@@ -4,12 +4,14 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
 public class FirebaseMessagingClient {
 
+  @Async("notificationExecutor")
   public void sendMessage(String fcmToken, String title, String body)
       throws FirebaseMessagingException {
     Message message = Message.builder()

--- a/src/main/java/org/project/sohwagi/infra/jpa/UserJpaRepository.java
+++ b/src/main/java/org/project/sohwagi/infra/jpa/UserJpaRepository.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.project.sohwagi.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -22,4 +23,5 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
       @Param("startYmd") int startYmd,
       @Param("endYmd") int endYmd);
 
+  List<User> findAllByIdIn(Set<Long> ids);
 }

--- a/src/main/java/org/project/sohwagi/infra/jpa/UserJpaRepository.java
+++ b/src/main/java/org/project/sohwagi/infra/jpa/UserJpaRepository.java
@@ -1,13 +1,25 @@
 package org.project.sohwagi.infra.jpa;
 
+import java.time.LocalDate;
+import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 import org.project.sohwagi.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserJpaRepository extends JpaRepository<User, Long> {
 
-	Optional<User> findByFcmToken(String fcmToken);
+  Optional<User> findByFcmToken(String fcmToken);
 
-	Optional<User> findByUserName(String userName);
+  Optional<User> findByUserName(String userName);
+
+  @Query("SELECT u FROM User u WHERE u.isDeleted = false AND NOT EXISTS " +
+      "(SELECT s FROM Schedule s WHERE s.userId = u.id AND " +
+      "(s.year * 10000 + s.month * 100 + s.day) BETWEEN :startYmd AND :endYmd)")
+  List<User> findActiveUsersWithoutSchedulesBetweenYmd(
+      @Param("startYmd") int startYmd,
+      @Param("endYmd") int endYmd);
 
 }

--- a/src/main/java/org/project/sohwagi/presentation/DailyNotificationScheduler.java
+++ b/src/main/java/org/project/sohwagi/presentation/DailyNotificationScheduler.java
@@ -14,7 +14,7 @@ public class DailyNotificationScheduler {
     this.scheduleNotificationService = scheduleNotificationService;
   }
 
-  @Scheduled(cron = "0 31 22 * * *", zone = "Asia/Seoul")
+  @Scheduled(cron = "0 00 09 * * *", zone = "Asia/Seoul")
   public void notifyTodaySchedules() throws FirebaseMessagingException {
     scheduleNotificationService.sendDailyScheduleNotifications();
   }

--- a/src/main/java/org/project/sohwagi/presentation/DailyNotificationScheduler.java
+++ b/src/main/java/org/project/sohwagi/presentation/DailyNotificationScheduler.java
@@ -19,4 +19,8 @@ public class DailyNotificationScheduler {
     scheduleNotificationService.sendDailyScheduleNotifications();
   }
 
+  @Scheduled(cron = "0 47 12 * * WED", zone = "Asia/Seoul")
+  public void notifyScheduleRegistrationPrompt() throws FirebaseMessagingException {
+    scheduleNotificationService.sendScheduleRegistrationNotifications();
+  }
 }

--- a/src/main/java/org/project/sohwagi/presentation/DailyNotificationScheduler.java
+++ b/src/main/java/org/project/sohwagi/presentation/DailyNotificationScheduler.java
@@ -14,9 +14,9 @@ public class DailyNotificationScheduler {
     this.scheduleNotificationService = scheduleNotificationService;
   }
 
-  @Scheduled(cron = "0 0 9 * * *", zone = "Asia/Seoul")
+  @Scheduled(cron = "0 31 22 * * *", zone = "Asia/Seoul")
   public void notifyTodaySchedules() throws FirebaseMessagingException {
-    scheduleNotificationService.notifyUsersOfTodaySchedules();
+    scheduleNotificationService.sendDailyScheduleNotifications();
   }
 
 }


### PR DESCRIPTION
### 개요
사용자 리텐션 및 서비스 활성화를 위해 스케줄링 기반의 FCM 푸시 알림 기능을 구현했다. 이번 PR은 아래 두 가지 주요 알림 기능과 비동기 처리를 통한 성능 최적화를 포함한다.
1. 데일리 스케줄 알림 : 매일 아침, 당일 일정이 있는 사용자에게 일정 정보를 알려준다.
2. 일정 등록 유도 알림 : 일주일간 활동이 없는 사용자에게 일정 등록을 유도하는 메세지를 보낸다.

### 주요 변경 사항
- 스케줄링 및 비동기 기능 활성화 (`SohwagiApplication`)
   - `@EnableScheduling`과 `@EnableAsync` 어노테이션을 추가하여 애플리케이션 전반에 스케줄링과 비동기 기능을 활성화했다.
- 푸시 알림 스케줄러 구현 (`DailyNotificationScheduler`)
   - `@Scheduled` 어노테이션을 사용하여 아래 두 가지 알림 작업을 등록했다.
       - 데일리 스케줄 알림 : `매일 오전 9시 (0 00 09 * * *)`
       - 일정 등록 유도 알림 : `매주 수요일 오후 12시 47분 (0 47 12 * * WED)`
- 푸시 알림 비즈니스 로직 구현 (`ScheduleNotificationService`)
   - `sendDailyScheduleNotifications()`: 당일 일정이 있는 모든 사용자를 조회하여 알림 메시지를 구성하는 로직을 구현했습니다.
   - `sendScheduleRegistrationNotifications()`: 최근 일주일간 일정이 없는 사용자를 조회하여 알림을 보내는 로직을 구현했습니다.
- 성능 최적화
   1. N+1 문제 해결 (`ScheduleNotificationService`) : 데일리 스케줄 알림 발송 시, 루프 내에서 각 사용자를 개별 조회하던 문제를 해결했다. `findAllByIdIn`을 사용하여 필요한 모든 사용자 정보를 단 한 번의 쿼리로 조회하도록 개선하여 DB 부하를 최소화 했다.
   2. 비동기 FCM 메세지 발송 (`FirebaseMessagingClient`, `AsyncConfig`)
       - `AsyncConfig`를 통해 FCM 발송 전용 스레드 풀(notificationExecutor)을 생성했다.
       - `FirebaseMessagingClient.sendMessage()` 메소드에 `@Async`를 적용하여, 네트워크 I/O 작업인 FCM 메시지 전송이 스케줄러의 메인 스레드를 블로킹하지 않도록 처리했다.
- 신규 조회 메소드 추가 (`UserJpaRepository`)
   - `findActiveUsersWithoutSchedulesBetweenYmd()` : 특정 기간에 일정이 없는 사용자를 조회하는 JPQL 쿼리를 추가했다.
   - `findAllByIdIn()` : N+1 문제 해결을 위해 ID 목록으로 여러 사용자를 한 번에 조회하는 메소드를 추가했다.

### 의사결정 흐름
- N+1 문제 해결의 필요성 : 초기 구현에서는 `scheduleMap`을 순회하며 각 `userId`로 `userService.findById()`를 호출했다. 이 방식은 알림 대상자가 N명일 때 총 N+1번의 쿼리를 발생시켜 사용자가 증가함에 따라 심각한 성능 저하를 유발할 수 있다고 판단했다. 따라서 루프 시작 전에 모든 사용자 정보를 한 번에 조회하는 방식으로 리팩토링했다.
- FCM 발송 비동기 처리 : FCM 메세지 전송은 외부 API를 호출하는 네트워크 I/O 작업으로, 응답 지연이 발생할 수 있다. 만약 이 작업을 동기적으로 처리하면, 하나의 메세지 전송이 지연될 경우 전체 스케줄링 스레드가 멈춰 후속 알림 전체가 지연되는 문제가 발생한다. 이를 방지하고 안정적인 대량 발송을 위해 `@Async`를 이용한 비동기 처리를 도입했다.
- `@Async` 적용 위치 : `@Async` 적용 시 발생할 수 있는 Self-invocation 문제를 피하기 위해, 비즈니스 로직 서비스(`ScheduleNotificationService`)가 아닌 실제 외부 통신을 담당하는 `FirebaseMessagingClient`에 `@Async`를 적용했다. 