### PR TITLE
배포 안정성 강화를 위한 CI Flyway 검증 추가

### DIFF
--- a/.github/workflows/cicd-prod.yml
+++ b/.github/workflows/cicd-prod.yml
@@ -29,8 +29,8 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-          
-      - name: Cache Gradle deps & wrapper   
+
+      - name: Cache Gradle deps & wrapper
         uses: actions/cache@v3
         with:
           path: |
@@ -39,7 +39,7 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*','**/gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-            
+
       - name: Make gradlew executable
         run: chmod +x ./gradlew
 
@@ -57,7 +57,10 @@ jobs:
       - name: Validate JSON file
         run: |
           cat src/main/resources/firebase-service-account.json | jq empty
-          
+
+      - name: Validate Flyway Migrations
+        run: ./gradlew flywayValidate
+
       - name: Build with Gradle
         run: ./gradlew clean build -x test
 

--- a/.github/workflows/cicd-test.yml
+++ b/.github/workflows/cicd-test.yml
@@ -54,6 +54,9 @@ jobs:
           mkdir -p src/main/resources
           echo "${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON_BASE64 }}" | base64 -d > src/main/resources/firebase-service-account.json
 
+      - name: Validate Flyway Migrations
+        run: ./gradlew flywayValidate
+
       - name: Validate JSON file
         run: |
           cat src/main/resources/firebase-service-account.json | jq empty


### PR DESCRIPTION
### 개요
- Closes #98 
지난 6월 30일, Flyway 체크섬 불일치로 인해 운영(prod) 환경 배포가 실패하고 약 1시간 동안 장애가 지속되는 문제가 발생했다. 이러한 인적 실수가 production 장애로 이어지는 것을 원천적으로 방지하기 위해, CI 단계에서 데이터베이스 마이그레이션의 정합성을 사전에 검증하는 작업을 추가했다. 
이제 `prod`, `test` 브랜치에 코드가 푸시되면, 실제 빌드 및 배포를 진행하기 전에 Flyway 스크립트가 운영 DB의 상태와 일치하는지 자동으로 검사하게 된다.

### 주요 변경 사항
- 워크플로우 수정
   - 기존 `Build with Gradle` 단계 이전에 `Validate Flyway Migrations` 단계를 추가했다.
   - 해당 단계는 `./gradlew flywayValidate` 명령어를 실행한다.
   - 이 명령어는 CI 환경에서 secrets을 통해 생성된 `application.properties`를 사용하여 실제 DB에 접속하고, 로컬 마이그레이션 스크립트와 DB의 `flyway_schema_history`를 비교한다.
   - 체크섬 불일치 등 문제가 발견되면, 워크플로우는 빌드 및 배포 단계를 실행하기 전에 실패하여 안전하게 배포를 차단한다.