### PR TITLE
Firebase service account 키 jar 포함 및 Gradle 리소스 설정 정리

### DIFF
--- a/.github/workflows/cicd-prod.yml
+++ b/.github/workflows/cicd-prod.yml
@@ -56,7 +56,12 @@ jobs:
 
       - name: Validate JSON file
         run: |
-          cat src/main/resources/firebase-service-account.json | jq empty
+          if [ ! -s src/main/resources/firebase-service-account.json ]; then
+            echo "❌ firebase-service-account.json is missing or empty"
+            exit 1
+          fi
+          jq empty src/main/resources/firebase-service-account.json
+          echo "✅ Firebase service account key validated"
 
       - name: Validate Flyway Migrations
         run: ./gradlew flywayValidate

--- a/.github/workflows/cicd-test.yml
+++ b/.github/workflows/cicd-test.yml
@@ -59,7 +59,12 @@ jobs:
 
       - name: Validate JSON file
         run: |
-          cat src/main/resources/firebase-service-account.json | jq empty
+          if [ ! -s src/main/resources/firebase-service-account.json ]; then
+            echo "❌ firebase-service-account.json is missing or empty"
+            exit 1
+          fi
+          jq empty src/main/resources/firebase-service-account.json
+          echo "✅ Firebase service account key validated"
 
       - name: Build with Gradle
         run: ./gradlew clean build -x test

--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,11 @@ bootJar {
     archiveClassifier.set('')
 }
 
+tasks.processResources {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    from("src/main/resources/firebase-service-account.json")
+}
+
 dependencyManagement {
     imports {
         mavenBom "org.springframework.ai:spring-ai-bom:$springAiVersion"

--- a/src/main/java/org/project/sohwagi/infra/firebase/FirebaseInitialization.java
+++ b/src/main/java/org/project/sohwagi/infra/firebase/FirebaseInitialization.java
@@ -5,6 +5,7 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import javax.annotation.PostConstruct;
 import org.springframework.stereotype.Component;
 
@@ -14,15 +15,17 @@ public class FirebaseInitialization {
   @PostConstruct
   public void init() {
     try {
-      FileInputStream serviceAccount = new FileInputStream(
-          "src/main/resources/firebase-service-account.json");
-
+      InputStream serviceAccount = getClass()
+          .getClassLoader()
+          .getResourceAsStream("firebase-service-account.json");
+      if (serviceAccount == null) {
+        throw new IllegalStateException("❌ firebase-service-account.json not found in classpath!");
+      }
       FirebaseOptions options = FirebaseOptions.builder()
           .setCredentials(GoogleCredentials.fromStream(serviceAccount))
           .build();
-
       FirebaseApp.initializeApp(options);
-    }catch (IOException e) {
+    } catch (IOException e) {
       e.printStackTrace();
     }
   }


### PR DESCRIPTION
### 개요
이번 PR은 Firebase 서비스 계정 키(firebase-service-account.json)를 빌드 산출물(jar)에 포함하도록 Gradle 및 CI/CD 워크플로우 구성을 정리한 작업이다.
그동안 EC2 배포 시 Firebase 초기화 단계에서 키 파일이 누락되어 FileNotFoundException이 발생하는 문제가 있었으며,
이를 해결하기 위해 GitHub Actions에서 base64로 생성된 JSON 파일을 빌드 시점에 함께 패키징하도록 변경했다.

### 주요 변경 사항
1. Gradle 리소스 처리 개선
- `build.gradle`
   ```
    tasks.processResources {
           duplicatesStrategy = DuplicatesStrategy.INCLUDE
           from("src/main/resources/firebase-service-account.json")
    }
    ```
    - Gradle이 firebase-service-account.json을 리소스로 강제로 포함하도록 수정했다.
    - DuplicatesStrategy를 추가하여 중복 리소스 복사 시 충돌을 방지했다.
2. Firbase 초기화 로직 수정
- 기존 `FileInputStream("src/main/resources/...")`을
`getResourceAsStream("firebase-service-account.json")` 방식으로 변경했다.
```
InputStream serviceAccount = getClass()
    .getClassLoader()
    .getResourceAsStream("firebase-service-account.json");

if (serviceAccount == null) {
    throw new IllegalStateException("❌ firebase-service-account.json not found in classpath!");
}
```
   - jar 내부 리소스에서도 정상적으로 Firebase SDK를 초기화할 수 있도록 했다.
   - null 안전성 검사를 추가하여 빌드 누락 시 명확한 에러 메시지를 출력하도록 했다.
3. CI/CD 워크플로우 강화
- cicd-test.yml, cicd-prod.yml에서 JSON 유효성 검증 로직을 강화했다.
```
if [ ! -s src/main/resources/firebase-service-account.json ]; then
    echo "❌ firebase-service-account.json is missing or empty"
    exit 1
fi
jq empty src/main/resources/firebase-service-account.json
echo "✅ Firebase service account key validated"
```
    - 파일 누락 및 비정상 base64 디코딩을 방지하도록 했다.

### 참고 및 주의사항
⚠️ 이 방법은 Firebase 서비스 계정 키를 jar 내부에 강제로 포함시키는 방식이므로, 보안상 완전한 해결책이 아니다.
빌드 산출물(jar)에 비밀 키(JSON)가 포함되면,
누구든 해당 jar를 추출(jar xf)하여 firebase-service-account.json 내용을 볼 수 있다.
즉, 소스코드에는 키가 포함되지 않더라도, 배포 파일 자체가 민감정보를 내포하게 된다.
따라서 추후에는 AWS Secrets Manager 또는 **환경변수 기반 로드(FIREBASE_CREDENTIAL_PATH)**로 전환하는 것이 바람직하다.

### 관련 이슈
Closes #129 