### PR TITLE
Gradle 플러그인에 Flyway 포함

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.4.4'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.flywaydb.flyway' version '10.18.0'
 }
 
 ext {


### PR DESCRIPTION
### 개요
CI/CD 환경에서 flywayValidate task가 인식되지 않아 빌드가 실패하던 문제를 수정했다.
org.flywaydb.flyway Gradle 플러그인을 추가하여 Flyway 관련 태스크(flywayValidate, flywayMigrate 등)가 정상적으로 등록되도록 했다.

### 주요 변경 사항
- `build.gradle`
   - 플러그인 추가를 통해 CI/CD 단계의 Flyway 검증(./gradlew flywayValidate)이 정상 수행되도록 수정함.

### 관련 이슈
Closes #132 