### PR TITLE
스케줄링 푸시 알림 오류 해결 및 데일리 푸시 알림 구현

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -29,7 +29,7 @@ echo "$TIME_NOW > ✅ FirebaseKey set to $FirebaseKey" >> $DEPLOY_LOG
 echo "$TIME_NOW > ✅ GOOGLE_APPLICATION_CREDENTIALS set to $GOOGLE_APPLICATION_CREDENTIALS" >> $DEPLOY_LOG
 
 # jar 파일 실행
-nohup java -Xlog:gc*:file=$GC_LOG_PATH:time,uptimemillis:filecount=10,filesize=10m -jar $JAR_FILE > $APP_LOG 2> $ERROR_LOG &
+nohup java -Xlog:gc*:file=$GC_LOG_PATH:time,uptimemillis:filecount=10,filesize=10m -Duser.timezone=Asia/Seoul -jar $JAR_FILE > $APP_LOG 2> $ERROR_LOG &
 
 CURRENT_PID=$(pgrep -f $JAR_FILE)
 echo "$TIME_NOW > 실행된 프로세스 PID: $CURRENT_PID" >> $DEPLOY_LOG

--- a/src/main/java/org/project/sohwagi/application/facade/ScheduleNotificationService.java
+++ b/src/main/java/org/project/sohwagi/application/facade/ScheduleNotificationService.java
@@ -12,6 +12,7 @@ import org.project.sohwagi.application.service.UserService;
 import org.project.sohwagi.domain.Schedule;
 import org.project.sohwagi.domain.User;
 import org.project.sohwagi.infra.firebase.FirebaseMessagingClient;
+import org.springframework.cglib.core.Local;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -29,7 +30,7 @@ public class ScheduleNotificationService {
     this.userService = userService;
   }
 
-  public void sendDailyScheduleNotifications() throws FirebaseMessagingException {
+  public void sendDailyScheduleNotifications() {
     LocalDate today = LocalDate.now();
 
     List<Schedule> todaySchedules = scheduleService.findTodaySchedules(today);
@@ -62,7 +63,7 @@ public class ScheduleNotificationService {
     }
   }
 
-  public void sendScheduleRegistrationNotifications() throws FirebaseMessagingException {
+  public void sendScheduleRegistrationNotifications() {
     LocalDate today = LocalDate.now();
     LocalDate sevenDaysAgo = today.minusDays(6);
     List<User> targets = userService.findUsersWithoutSchedulesInLastWeek(today, sevenDaysAgo);
@@ -71,6 +72,19 @@ public class ScheduleNotificationService {
       String body = "메모하듯이 한 문장으로 빠르게 입력해보세요!";
 
       firebaseMessagingClient.sendMessage(target.getFcmToken(), title, body);
+    }
+  }
+
+  public void sendDailyScheduleRegistrationNotifications() {
+    List<User> users = userService.findAllUsers();
+    for (User user : users) {
+      if(user.getFcmToken() == null || user.getFcmToken().isEmpty()) {
+        continue;
+      }
+      String name = user.getUserName().split(" ")[0];
+      String title = name + "햄! 지금 생각난 일정 한 줄로 남겨두자 햄!";
+      String body = "지금 떠오른 그 일정을 한 줄로 남겨보세요!";
+      firebaseMessagingClient.sendMessage(user.getFcmToken(), title, body);
     }
   }
 }

--- a/src/main/java/org/project/sohwagi/application/service/UserService.java
+++ b/src/main/java/org/project/sohwagi/application/service/UserService.java
@@ -74,6 +74,10 @@ public class UserService {
         () -> saveUser(userName, "TEST_PROVIDER", userName + "@test.com"));
   }
 
+  public List<User> findAllUsers() {
+    return userRepository.findAllUsers();
+  }
+
   private String convertName(String name) {
     if (name.contains(" ")) {
       String[] parts = name.split(" ");

--- a/src/main/java/org/project/sohwagi/domain/UserRepository.java
+++ b/src/main/java/org/project/sohwagi/domain/UserRepository.java
@@ -50,4 +50,7 @@ public class UserRepository {
     return userJpaRepository.findByUserName(userName);
   }
 
+  public List<User> findAllUsers() {
+    return userJpaRepository.findAll();
+  }
 }

--- a/src/main/java/org/project/sohwagi/infra/firebase/FirebaseMessagingClient.java
+++ b/src/main/java/org/project/sohwagi/infra/firebase/FirebaseMessagingClient.java
@@ -1,8 +1,6 @@
 package org.project.sohwagi.infra.firebase;
 
-import com.google.firebase.messaging.FirebaseMessaging;
-import com.google.firebase.messaging.FirebaseMessagingException;
-import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
@@ -13,11 +11,30 @@ public class FirebaseMessagingClient {
 
   @Async("notificationExecutor")
   public void sendMessage(String fcmToken, String title, String body) {
+    Notification notification = Notification.builder()
+      .setTitle(title)
+      .setBody(body)
+      .build();
+
+    ApsAlert alert = ApsAlert.builder()
+      .setTitle(title)
+      .setBody(body)
+      .build();
+
+    Aps aps = Aps.builder()
+      .setAlert(alert)
+      .setSound("default")
+      .build();
+
+    ApnsConfig apnsConfig = ApnsConfig.builder()
+      .setAps(aps)
+      .build();
+
     Message message = Message.builder()
-        .putData("title", title)
-        .putData("body", body)
-        .setToken(fcmToken)
-        .build();
+      .setNotification(notification)
+      .setApnsConfig(apnsConfig)
+      .setToken(fcmToken)
+      .build();
 
     try {
       String response = FirebaseMessaging.getInstance().send(message);

--- a/src/main/java/org/project/sohwagi/presentation/DailyNotificationScheduler.java
+++ b/src/main/java/org/project/sohwagi/presentation/DailyNotificationScheduler.java
@@ -17,14 +17,20 @@ public class DailyNotificationScheduler {
   }
 
   @Scheduled(cron = "0 00 09 * * *", zone = "Asia/Seoul")
-  public void notifyTodaySchedules() throws FirebaseMessagingException {
+  public void notifyTodaySchedules() {
     log.info("📅 [DailyNotificationScheduler] start");
     scheduleNotificationService.sendDailyScheduleNotifications();
   }
 
   @Scheduled(cron = "0 47 12 * * WED", zone = "Asia/Seoul")
-  public void notifyScheduleRegistrationPrompt() throws FirebaseMessagingException {
+  public void notifyScheduleRegistrationPrompt() {
     log.info("📅 [DailyNotificationScheduler] start");
     scheduleNotificationService.sendScheduleRegistrationNotifications();
+  }
+
+  @Scheduled(cron = "0 16 08 * * *", zone = "Asia/Seoul")
+  public void notifyDailyScheduleRegistration() {
+    log.info("📅 [DailyNotificationScheduler] start");
+    scheduleNotificationService.sendDailyScheduleRegistrationNotifications();
   }
 }


### PR DESCRIPTION
### 개요
전 사용자 대상 데일리 푸시 기능 추가와 기존 iOS FCM 알림 문제 해결을 포함한 스케줄링/FCM 관련 개선을 적용했다. 또한 서버 타임존을 명시적으로 `Asia/Seoul`로 지정하여 스케줄 실행 시점의 일관성을 확보했다.

### 주요 변경 사항
1) JVM 타임존 명시적 설정
- `start.sh`에 `-Duser.timezone=Asia/Seoul` 추가
2) iOS 프로덕션 환경 FCM 알림 오류 수정
- 기존의 `data-only` FCM 메세지 제거
- `Notification`, `ApsAlert`, `Aps`, `ApnsConfig`를 포함한 APNs 규격 메시지로 교체
- iOS 실기기/프로덕션에서 푸시가 표시되지 않던 문제 해결 
3) 새로운 데일리 푸시 알림 기능 추가
- 전 사용자 대상 "일정 한 줄 등록" 유도 푸시
- `sendDailyScheduleRegistrationNotifications()` 신규 추가
- 모든 사용자 조회 후
   - 이름 추출
   - "예진햄! 지금 생각난 일정 한 줄로 남겨두자 햄!" 형태로 푸시 전송

### 관련 이슈
#137 